### PR TITLE
Add os mapping capability

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Command structure is:
 ```
-./inventoryware NODE ZIP_LOCATION -p PRI_GROUP -s LIST,OF,SECONDARY,GROUPS -t TEMPLATE_LOCATION
+./inventoryware NODE ZIP_LOCATION -p PRI_GROUP -s LIST,OF,SECONDARY,GROUPS -t TEMPLATE_LOCATION -o OS
 ```
 
 The zip must contain a lshw-xml.txt and a lsblk-a-P.txt

--- a/README.md
+++ b/README.md
@@ -36,3 +36,15 @@ gem install rerun # If you don't have this already.
 make watch-rsync PASSWORD="password for machine" IP="ip of machine"
 ```
 This will keep your working directory synced to `/tmp/inventoryware`
+
+## Creating Templates
+
+Templates accepted by Inventoryware are .erb templates filled using Erubis. The relevant data
+is stored in and referenced from a large hash named `hash`. The top level keys indicate the
+source of the underlying data: 'Name', 'Primary Group' and 'Secondary Group' are filled via the
+command line, 'lshw' and 'lsblk are from their respective files in the zip.
+The method `find_hashes_with_key_value` is for use in navigating the hash, it will return all
+hashes with the given key-value pair regarless of it's depth in the hash.
+Additionally some fields are different based on the OS the target node uses. The OS must be
+specified via the command line and these fields must be referenced through the `mapping` obejct.
+See the example template for these methods in practice.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Command structure is:
 ```
-./inventoryware NODE ZIP_LOCATION -p PRI_GROUP -s LIST,OF,SECONDARY,GROUPS -t TEMPLATE_LOCATION -o OS
+./inventoryware NODE ZIP_LOCATION [-p PRI_GROUP] [-s LIST,OF,SECONDARY,GROUPS] [-t TEMPLATE_LOCATION -m MAP]
 ```
 
 The zip must contain a lshw-xml.txt and a lsblk-a-P.txt
@@ -45,6 +45,7 @@ source of the underlying data: 'Name', 'Primary Group' and 'Secondary Group' are
 command line, 'lshw' and 'lsblk are from their respective files in the zip.
 The method `find_hashes_with_key_value` is for use in navigating the hash, it will return all
 hashes with the given key-value pair regarless of it's depth in the hash.
-Additionally some fields are different based on the OS the target node uses. The OS must be
-specified via the command line and these fields must be referenced through the `mapping` obejct.
+Additionally some fields are different based on qualities of the node. These must be specified
+via the command line and these fields are referenced through the `mapping` obejct. At the moment
+this is just if the commands were run in a vm.
 See the example template for these methods in practice.

--- a/example_template.md.erb
+++ b/example_template.md.erb
@@ -22,7 +22,7 @@
   <% find_hashes_with_key_value(hash, 'class', 'processor').each do |cpu| %>
   ### <%= cpu['id'] %>
 
-  model: <%= cpu[MAPPING[os]['cpu_model']] %>
+  model: <%= cpu[mapping['cpu_model']] %>
   slot: <%= cpu['slot'] %>
 
   <% end %>

--- a/example_template.md.erb
+++ b/example_template.md.erb
@@ -22,7 +22,7 @@
   <% find_hashes_with_key_value(hash, 'class', 'processor').each do |cpu| %>
   ### <%= cpu['id'] %>
 
-  model: <%= cpu['version'] %>
+  model: <%= cpu[MAPPING[os]['cpu_model']] %>
   slot: <%= cpu['slot'] %>
 
   <% end %>

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -30,7 +30,7 @@ class MainParser
   options['template'] = nil
 
   opt_parser = OptionParser.new do |opt|
-    opt.banner = "Usage inventoryware NODE_NAME DATA [PRIMARY_GROUP]" +\
+    opt.banner = "Usage inventoryware NODE_NAME DATA [PRIMARY_GROUP]" + \
       " [SECONDARY_GROUPS] [TEMPLATE]"
 
     opt.on("-p", "--primary-group PRIMARY-GROUP",
@@ -44,8 +44,15 @@ class MainParser
     end
 
     opt.on("-t", "--template TEMPLATE",
-           "Path to desired template, if blank yaml will be output") do |templ|
+           "Path to desired template. " + \
+           "If not sepecified, yaml will be output") do |templ|
       options['template'] = templ
+    end
+
+    opt.on("-o", "--operating-system OPERATING-SYSTEM",
+           "The operating system version on the node. " + \
+           "Accepted values are #{MAPPING.keys.join(" & ")}") do |os|
+      options["os"] = os
     end
 
     opt.on("-h","--help","Show this help screen") do

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -49,10 +49,10 @@ class MainParser
       options['template'] = templ
     end
 
-    opt.on("-o", "--operating-system OPERATING-SYSTEM",
-           "The operating system version on the node. " + \
-           "Accepted values are #{MAPPING.keys.join(" & ")}") do |os|
-      options["os"] = os
+    opt.on("-m", "--mapping MAPPING-INFO",
+           "Information for lshw field mapping. " + \
+           "Accepted values are #{MAPPING.keys.join(" & ")}") do |map|
+      options["map"] = map
     end
 
     opt.on("-h","--help","Show this help screen") do

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -146,7 +146,7 @@ begin
     template = File.read(options['template'])
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
-    template_out_file = "#{OUTPUT_DIR}/#{template_out_name}"
+    template_out_file = File.join(OUTPUT_DIR, template_out_name)
     # overrides existing target file
     File.open(template_out_file, 'w') do |file|
       file.write(eruby.result(binding()))

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -50,7 +50,7 @@ end
 OUTPUT_DIR = '/opt/inventoryware/output'
 YAML_FILE = "#{OUTPUT_DIR}/domain"
 REQ_FILES = ["lshw-xml", "lsblk-a-P"]
-MAPPING = YAML.load_file(File.join(File.dirname(__FILE__), "../mapping.yaml"))
+MAPPING = YAML.load_file(File.join(lib_dir, "../mapping.yaml"))
 
 begin
   #create a tmp file for each required file

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -36,7 +36,6 @@ end
 
 require_relative 'cli'
 require_relative 'lsblk_parser'
-require_relative 'mapper'
 require_relative 'utils'
 require 'erubis'
 require 'tmpdir'
@@ -51,6 +50,7 @@ end
 OUTPUT_DIR = '/opt/inventoryware/output'
 YAML_FILE = "#{OUTPUT_DIR}/domain"
 REQ_FILES = ["lshw-xml", "lsblk-a-P"]
+MAPPING = YAML.load_file(File.join(File.dirname(__FILE__), "../mapping.yaml"))
 
 begin
   #create a tmp file for each required file
@@ -142,7 +142,7 @@ begin
       puts "Accepted values are #{MAPPING.keys.join(" & ")}."
       exit
     end
-    os = options['os']
+    mapping = MAPPING[options['os']]
     template = File.read(options['template'])
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -137,12 +137,12 @@ begin
 
   # output
   if options['template']
-    unless MAPPING.keys.include? options['os']
-      puts "Please provide a valid operating system version before continuing."
+    unless MAPPING.keys.include? options['map']
+      puts "Please provide valid lshw mapping information before continuing."
       puts "Accepted values are #{MAPPING.keys.join(" & ")}."
       exit
     end
-    mapping = MAPPING[options['os']]
+    mapping = MAPPING[options['map']]
     template = File.read(options['template'])
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -36,6 +36,7 @@ end
 
 require_relative 'cli'
 require_relative 'lsblk_parser'
+require_relative 'mapper'
 require_relative 'utils'
 require 'erubis'
 require 'tmpdir'
@@ -136,6 +137,12 @@ begin
 
   # output
   if options['template']
+    unless MAPPING.keys.include? options['os']
+      puts "Please provide a valid operating system version before continuing."
+      puts "Accepted values are #{MAPPING.keys.join(" & ")}."
+      exit
+    end
+    os = options['os']
     template = File.read(options['template'])
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -63,8 +63,8 @@ begin
   # parse remaining options
   options = MainParser.parse(ARGV)
 
-  if ARGV.length() < 2
-    puts "Node and data source not specified"
+  unless ARGV.length() == 2
+    puts "Node and data source should be the only two arguments specified."
     exit
   end
 

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -1,0 +1,8 @@
+MAPPING = {
+  'el6' => {
+    'cpu_model' => 'version',
+  },
+  'el7' => {
+    'cpu_model' => 'model',
+  }
+}

--- a/lib/mapper.rb
+++ b/lib/mapper.rb
@@ -1,8 +1,0 @@
-MAPPING = {
-  'el6' => {
-    'cpu_model' => 'version',
-  },
-  'el7' => {
-    'cpu_model' => 'model',
-  }
-}

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -1,0 +1,4 @@
+el6:
+  cpu_model: version
+el7:
+  cpu_model: model

--- a/mapping.yaml
+++ b/mapping.yaml
@@ -1,4 +1,4 @@
-el6:
+non-vm:
   cpu_model: version
-el7:
+vm:
   cpu_model: model


### PR DESCRIPTION
To prevent needing to redefine templates based on the target node's OS (as different node OS presents different lshw output)
Create hash to store various fields based on OS.
OS is currently passed as a CLI option that is necessary if a template is being used. This will likely change to being scrubbed when more input data is added.

@ColonelPanicks:
The template syntax looks like so: `<%= cpu[mapping['cpu_model']] %>` How's this with you?

& I defined the mapping in a ruby hash in a separate module (mapper) , how is this solution with you?
I saw that you wrote it in a psuedo yaml style, would this be better?