### PR TITLE
Add CLI option for output location

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@
 
 Command structure is:
 ```
-./inventoryware NODE ZIP_LOCATION [-p PRI_GROUP] [-s LIST,OF,SECONDARY,GROUPS] [-t TEMPLATE_LOCATION -m MAP]
+./inventoryware NODE ZIP_LOCATION [-p PRI_GROUP] [-s LIST,OF,SECONDARY,GROUPS] [-t TEMPLATE_LOCATION -m MAP] [-l OUTPUT_DESTINATION]
 ```
 
 The zip must contain a lshw-xml.txt and a lsblk-a-P.txt
 
-Output is to a fixed location - `/opt/inventoryware/output/domain`
+If no destination is provided the output is stored in `/opt/inventoryware/output`. Here all yaml is
+added to the file `domain` and all templates are store in a file titled `NODE_TEMPLATE.md.erb`.
+If a destination is provided, templates append to the specified location rather than override (as 
+they do in the default).
 If no template is provided the node's information is appended to the destination file.
 If a template is provided it is filled as eRuby and the desitation file is overwritten with the
 resulting markdown.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Command structure is:
 The zip must contain a lshw-xml.txt and a lsblk-a-P.txt
 
 If no destination is provided the output is stored in `/opt/inventoryware/output`. Here all yaml is
-added to the file `domain` and all templates are store in a file titled `NODE_TEMPLATE.md.erb`.
-If a destination is provided, templates append to the specified location rather than override (as 
-they do in the default).
+added to the file `domain` and all templates are stored in a file titled `NODE_TEMPLATE.md.erb`.
+
 If no template is provided the node's information is appended to the destination file.
-If a template is provided it is filled as eRuby and the desitation file is overwritten with the
+
+If a template is provided it is filled as eRuby and the destination file is overwritten with the
 resulting markdown.
 
 ## Installation
@@ -50,5 +50,5 @@ The method `find_hashes_with_key_value` is for use in navigating the hash, it wi
 hashes with the given key-value pair regarless of it's depth in the hash.
 Additionally some fields are different based on qualities of the node. These must be specified
 via the command line and these fields are referenced through the `mapping` obejct. At the moment
-this is just if the commands were run in a vm.
+this is just if the commands were/were not run in a vm.
 See the example template for these methods in practice.

--- a/lib/cli.rb
+++ b/lib/cli.rb
@@ -49,6 +49,11 @@ class MainParser
       options['template'] = templ
     end
 
+    opt.on("-l", "--location OUTPUT-LOCATION",
+           "Path to the desired output file.") do |location|
+      options['location'] = location
+    end
+
     opt.on("-m", "--mapping MAPPING-INFO",
            "Information for lshw field mapping. " + \
            "Accepted values are #{MAPPING.keys.join(" & ")}") do |map|

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -129,15 +129,16 @@ begin
   # confirm file location exists
   # decided against creating location if it did not exist as it requires sudo
   #   execution - it may be that this would be better changed
-  if !File.directory?(OUTPUT_DIR)
+  if options['location']
+    unless validate_file(options['location'])
+      puts "Invalid destination '#{options['location']}'"
+      exit
+    end
+    out_file = options['locations']
+  elsif !File.directory?(OUTPUT_DIR)
     puts "Directory #{OUTPUT_DIR} not found - please create it "\
       "before contining."
     exit
-  end
-
-  #TODO verify output location
-  if options['location']
-    out_file = options['location']
   end
 
   # output
@@ -152,7 +153,6 @@ begin
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
     out_file ||= File.join(OUTPUT_DIR, template_out_name)
-    # overrides existing target file
     File.open(out_file, 'w') do |file|
       file.write(eruby.result(binding()))
     end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -126,8 +126,6 @@ begin
     }
   end
 
-  file_mode = 'w'
-
   # confirm file location exists
   # decided against creating location if it did not exist as it requires sudo
   #   execution - it may be that this would be better changed
@@ -137,7 +135,6 @@ begin
       exit
     end
     out_file = options['location']
-    file_mode = 'a'
   elsif !File.directory?(OUTPUT_DIR)
     puts "Directory #{OUTPUT_DIR} not found - please create it "\
       "before contining."
@@ -156,7 +153,7 @@ begin
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
     out_file ||= File.join(OUTPUT_DIR, template_out_name)
-    File.open(out_file, file_mode) do |file|
+    File.open(out_file, 'w') do |file|
       file.write(eruby.result(binding()))
     end
   else
@@ -172,7 +169,7 @@ begin
     end
     yaml_hash[hash['Name']] = hash
     yaml_hash = Hash[yaml_hash.sort_by { |k,v| k }]
-    File.open(out_file, file_mode) { |file| file.write(yaml_hash.to_yaml) }
+    File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
   end
 ensure
   FileUtils.remove_entry dir

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -145,8 +145,12 @@ begin
     mapping = MAPPING[options['map']]
     template = File.read(options['template'])
     eruby = Erubis::Eruby.new(template)
-    template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
-    template_out_file = File.join(OUTPUT_DIR, template_out_name)
+    if options['location']
+      template_out_file = options['location']
+    else
+      template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
+      template_out_file = File.join(OUTPUT_DIR, template_out_name)
+    end
     # overrides existing target file
     File.open(template_out_file, 'w') do |file|
       file.write(eruby.result(binding()))

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -126,6 +126,8 @@ begin
     }
   end
 
+  file_mode = 'w'
+
   # confirm file location exists
   # decided against creating location if it did not exist as it requires sudo
   #   execution - it may be that this would be better changed
@@ -134,7 +136,8 @@ begin
       puts "Invalid destination '#{options['location']}'"
       exit
     end
-    out_file = options['locations']
+    out_file = options['location']
+    file_mode = 'a'
   elsif !File.directory?(OUTPUT_DIR)
     puts "Directory #{OUTPUT_DIR} not found - please create it "\
       "before contining."
@@ -153,7 +156,7 @@ begin
     eruby = Erubis::Eruby.new(template)
     template_out_name = "#{hash['Name']}_#{File.basename(options['template'])}"
     out_file ||= File.join(OUTPUT_DIR, template_out_name)
-    File.open(out_file, 'w') do |file|
+    File.open(out_file, file_mode) do |file|
       file.write(eruby.result(binding()))
     end
   else
@@ -169,7 +172,7 @@ begin
     end
     yaml_hash[hash['Name']] = hash
     yaml_hash = Hash[yaml_hash.sort_by { |k,v| k }]
-    File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
+    File.open(out_file, file_mode) { |file| file.write(yaml_hash.to_yaml) }
   end
 ensure
   FileUtils.remove_entry dir

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -20,6 +20,13 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
+def validate_file(path)
+  return false if File.directory?(path)
+  return false unless File.directory?(File.dirname(path))
+  return false if File.exists?(path) && !File.writable?(path)
+  return true
+end
+
 # 'value' can be a regular expression or a plain old string
 def find_hashes_with_key_value(obj, key, value, store = [])
   if obj.respond_to?(:key?) && obj.key?(key) && /#{value}/.match(obj[key])


### PR DESCRIPTION
-l CLI option specifies output location 

If not set uses `/opt/inventoryware/ouput` still
Acts the same way as it used to, templates override existing files & yaml concatenates 