### PR TITLE
Batch Commands

### DIFF
--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -1,74 +1,142 @@
-
 require 'xmlhasher'
-require 'tmpdir'
 require 'zip'
 
 module Inventoryware
   module Commands
     class Parse < Command
+      # maybe make this work with >1 level?
+      def expand_dir(data_source)
+        contents = []
+        if File.directory?(data_source)
+          Dir.foreach(data_source) do |item|
+            next if item == '.' or item == '..'
+            next unless check_zip?(item)
+            contents.push(File.join(data_source, item))
+          end
+        elsif check_zip_exists?(data_source)
+          contents = [data_source]
+        end
+        if contents.empty?
+          p "No .zip files found at #{data_source}"
+          exit
+        end
+        return contents
+      end
+
+      def recursively_extract_zips(target_dir)
+        things_changed = false
+        Dir[File.join(target_dir, '**/*.zip')].each do |zip_path|
+          extract_zip(zip_path, target_dir)
+          File.delete(zip_path)
+          things_changed = true
+        end
+        recursively_extract_zips(target_dir) if things_changed
+      end
+
+      def extract_zip(zip_path, destination)
+        Zip::File.open(zip_path) do |zip_file|
+          zip_name = File.basename(zip_file.name, '.zip')
+          zip_file.each do |item|
+            item_path = File.join(destination, zip_name, item.name)
+            FileUtils.mkdir_p(File.dirname(item_path))
+            zip_file.extract(item, item_path) unless File.exist?(item_path)
+          end
+        end
+      end
+
+      def clean_dir(dir)
+        # A bit of a hack to delete all directories with no files in them.
+        # By globbing then reversing the order you get a reversed-BFS.
+        # So all directories' items will preceded the directories themselves
+        # while being processed, allowing sequential deletion of empty dirs.
+        dir_items = Dir.glob(File.join(dir, "**/*"))
+        dir_items.reverse!
+        dir_items.each do |item|
+          if File.directory?(item) and Dir.empty?(item)
+            FileUtils.remove_dir(item)
+          end
+        end
+      end
+
+      def process_container_dir(dir)
+        Dir.foreach(dir) do |item|
+          next if item == '.' or item == '..'
+          if File.directory?(File.join(dir, item))
+            process_dir(File.join(dir, item))
+          end
+        end
+      end
+
+      def process_dir(dir)
+        node_name = File.basename(dir)
+        p "Importing #{node_name}.zip"
+
+        invalid = false
+        file_locations = {}
+        ALL_FILES.each do |file|
+          file_locations[file] = Dir.glob(File.join(dir, "#{file}*"))&.first
+          if not file_locations[file] and REQ_FILES.include?(file)
+            p "Warning: File #{file} required in #{node_name}.zip but not found."
+            invalid = true
+          end
+        end
+
+        if invalid
+          p "Skipping #{node_name}.zip"
+          return false
+        end
+
+        hash = {}
+        hash['Name'] = node_name
+        #TODO find which format the groups will be specifed in and scrub them
+        # extract data from lshw
+        hash['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))
+        # extract data from lsblk
+        hash['lsblk'] = LsblkParser.new(file_locations['lsblk-a-P']).hashify()
+
+        output_yaml(hash['Name'], hash)
+      end
+
       def output_yaml(name, hash)
         exit_unless_dir(YAML_DIR)
         yaml_out_name = "#{hash['Name']}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)
         yaml_hash = {hash['Name'] => hash}
         File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
+        p "#{name}.zip imported to #{File.expand_path(out_file)}"
       end
 
       def run
         unless @argv.length() == 1
-          puts "Error: The data source should be the only argument."
+          p "Error: The data source should be the only argument."
           exit
         end
-        data_source = @argv[0]
-        # confirm data exists and is in right format (.zip)
-        if not check_zip?(data_source)
-          puts "Error: data source #{data_source}"\
-               " - must be zip file"
-          exit
+
+        XmlHasher.configure do |config|
+          config.snakecase = true
+          config.ignore_namespaces = true
+          config.string_keys = true
         end
+
         begin
-          #create a tmp file for each required file
-          dir = Dir.mktmpdir('inv_ware_')
+          top_dir = Dir.mktmpdir('inv_ware_')
 
-          file_locations = {}
-          REQ_FILES.each do |file|
-            file_locations[file] = File.join(dir, file)
-          end
+          # get all zips in in the source, if it's a dir or not
+          top_lvl_zip_paths = expand_dir(@argv[0])
 
-          # unzip data and extract each required file to the created tmp files
-          Zip::File.open(data_source) do |zip_file|
-            zip_file.each do |entry|
-              puts "Extracting #{entry.name}"
-            end
-            if file_locations.all? { |file, v| zip_file.glob("#{file}*").first }
-              file_locations.each do |file, value|
-                zip_file.glob("#{file}*").first.extract(value)
-              end
-            else
-              puts "Error: #{REQ_FILES.join(" & ")} files required in .zip but not found."
-              exit
-            end
-          end
+          # for each of these, extract to /tmp/
+          top_lvl_zip_paths.each { |zip_path| extract_zip(zip_path, top_dir) }
 
-          XmlHasher.configure do |config|
-            config.snakecase = true
-            config.ignore_namespaces = true
-            config.string_keys = true
-          end
+          # extract any zips in these zips
+          recursively_extract_zips(top_dir)
 
-          hash = {}
-          # The node's name is inferred from the name of the .zip
-          # The second argument removes the extension
-          hash['Name'] = File.basename(data_source, ".*")
-          #TODO find which format the groups will be specifed in and scrub like that
-          # extract data from lshw
-          hash['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))
-          # extract data from lsblk
-          hash['lsblk'] = LsblkParser.new(file_locations['lsblk-a-P']).hashify()
+          # remove empty file paths from the tmp dir
+          clean_dir(top_dir)
 
-          output_yaml(hash['Name'], hash)
+          # parse the extracted files to yaml
+          process_container_dir(top_dir)
         ensure
-          FileUtils.remove_entry dir
+          FileUtils.remove_entry top_dir
         end
       end
     end

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -131,7 +131,10 @@ module Inventoryware
         exit_unless_dir(YAML_DIR)
         yaml_out_name = "#{hash['Name']}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)
-        #TODO check out_file writable but be fine if it doesn't exist
+        unless check_file_writable?(out_file)
+          p "Error: output file #{out_file} not accessible - aborting"
+          exit
+        end
         yaml_hash = {hash['Name'] => hash}
         File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
         p "#{name}.zip imported to #{File.expand_path(out_file)}"

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -39,15 +39,10 @@ module Inventoryware
       end
 
       private
-      # maybe make this work with >1 level?
       def expand_dir(data_source)
         contents = []
         if File.directory?(data_source)
-          Dir.foreach(data_source) do |item|
-            next if item == '.' or item == '..'
-            next unless check_zip?(item)
-            contents.push(File.join(data_source, item))
-          end
+          contents = Dir.glob(File.join(data_source, "**/*.zip"))
         elsif check_zip_exists?(data_source)
           contents = [data_source]
         end

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -4,70 +4,6 @@ require 'erubis'
 module Inventoryware
   module Commands
     class Render < Command
-      def gen_ctx_with_plugins(hash, template)
-        render_env = Module.new do
-          def hash
-            hash
-          end
-        end
-        Dir[File.join(LIB_DIR, '..', 'plugins', '*.rb')].each do |file|
-          render_env.instance_eval(File.read(file))
-        end
-        ctx = render_env.instance_eval { binding }
-      end
-
-      def find_all_nodes()
-        node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
-        if node_locations.empty?
-          p "Error: No node data found in #{YAML_DIR}"
-          exit
-        end
-        #TODO sort node_locations?
-        return node_locations
-      end
-
-      def find_nodes(nodes)
-        node_locations = []
-        nodes.each do |node|
-          node_yaml = "#{node}.yaml"
-          node_yaml_location = File.join(YAML_DIR, node_yaml)
-          unless check_file_readable?(node_yaml_location)
-            puts "Error: File #{node_yaml} not found within #{File.expand_path(YAML_DIR)}"
-            exit
-          end
-          node_locations.append(node_yaml_location)
-        end
-        return node_locations
-      end
-
-      def output(node_locations, template, out_file)
-        # TODO verify template contents?
-        template_contents = File.read(template)
-        eruby = Erubis::Eruby.new(template_contents)
-
-        out = ""
-        # check, will loading all output cause issues with memory size?
-        # probably fine - 723 nodes was 350Kb
-        node_locations.each do |node|
-          begin
-            # `.values[0]` it ignore the name of the node & just get its data
-            hash = YAML.load_file(node).values[0]
-          rescue Psych::SyntaxError
-            puts "Error: parsing yaml in #{node} - aborting"
-            exit
-          end
-
-          #TODO do we need to generate the entire context for each node
-          ctx = gen_ctx_with_plugins(hash, template_contents)
-          out += eruby.result(ctx)
-          p "Parsed #{File.basename(node)}"
-        end
-
-        File.open(out_file, 'w') do |file|
-          file.write(out)
-        end
-      end
-
       def run
         if @options.all and not @argv.length == 1
           puts "Error: 'template' should be the only argument - all nodes are being parsed."
@@ -104,8 +40,72 @@ module Inventoryware
                template,
                out_file
               )
+      end
 
-      #TODO encapsulate
+      private
+      def find_all_nodes()
+        node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
+        if node_locations.empty?
+          p "Error: No node data found in #{YAML_DIR}"
+          exit
+        end
+        #TODO sort node_locations?
+        return node_locations
+      end
+
+      def find_nodes(nodes)
+        node_locations = []
+        nodes.each do |node|
+          node_yaml = "#{node}.yaml"
+          node_yaml_location = File.join(YAML_DIR, node_yaml)
+          unless check_file_readable?(node_yaml_location)
+            puts "Error: File #{node_yaml} not found within #{File.expand_path(YAML_DIR)}"
+            exit
+          end
+          node_locations.append(node_yaml_location)
+        end
+        return node_locations
+      end
+
+      def output(node_locations, template, out_file)
+        # TODO verify template contents?
+        template_contents = File.read(template)
+        eruby = Erubis::Eruby.new(template_contents)
+
+        out = ""
+        # check, will loading all output cause issues with memory size?
+        # probably fine - 723 nodes was 350Kb
+        # TODO move this block to its own method
+        node_locations.each do |node|
+          begin
+            # `.values[0]` is to ignore the name of the node & just get its data
+            hash = YAML.load_file(node).values[0]
+          rescue Psych::SyntaxError
+            puts "Error: parsing yaml in #{node} - aborting"
+            exit
+          end
+
+          #TODO do we need to generate the entire context for each node
+          ctx = gen_ctx_with_plugins(hash, template_contents)
+          out += eruby.result(ctx)
+          p "Parsed #{File.basename(node)}"
+        end
+
+        File.open(out_file, 'w') do |file|
+          file.write(out)
+        end
+      end
+
+      def gen_ctx_with_plugins(hash, template)
+        render_env = Module.new do
+          def hash
+            hash
+          end
+        end
+        Dir[File.join(LIB_DIR, '..', 'plugins', '*.rb')].each do |file|
+          render_env.instance_eval(File.read(file))
+        end
+        ctx = render_env.instance_eval { binding }
       end
     end
   end

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -75,25 +75,28 @@ module Inventoryware
         out = ""
         # check, will loading all output cause issues with memory size?
         # probably fine - 723 nodes was 350Kb
-        # TODO move this block to its own method
         node_locations.each do |node|
-          begin
-            # `.values[0]` is to ignore the name of the node & just get its data
-            hash = YAML.load_file(node).values[0]
-          rescue Psych::SyntaxError
-            puts "Error: parsing yaml in #{node} - aborting"
-            exit
-          end
-
-          #TODO do we need to generate the entire context for each node
-          ctx = gen_ctx_with_plugins(hash, template_contents)
-          out += eruby.result(ctx)
+          out += parse_yaml(node, eruby, template_contents)
           p "Parsed #{File.basename(node)}"
         end
 
         File.open(out_file, 'w') do |file|
           file.write(out)
         end
+      end
+
+      def parse_yaml(node, eruby, template_contents)
+        begin
+          # `.values[0]` is to ignore the name of the node & just get its data
+          hash = YAML.load_file(node).values[0]
+        rescue Psych::SyntaxError
+          puts "Error: parsing yaml in #{node} - aborting"
+          exit
+        end
+
+        #TODO do we need to generate the entire context for each node?
+        ctx = gen_ctx_with_plugins(hash, template_contents)
+        eruby.result(ctx)
       end
 
       def gen_ctx_with_plugins(hash, template)

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -49,7 +49,6 @@ module Inventoryware
           p "Error: No node data found in #{YAML_DIR}"
           exit
         end
-        #TODO sort node_locations?
         return node_locations
       end
 

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -67,19 +67,24 @@ module Inventoryware
       end
 
       def output(node_locations, template, out_file)
-        node_locations = node_locations.sort_by { |location|
+        node_locations = node_locations.sort_by do |location|
           File.basename(location)
-        }
+        end
 
         # TODO verify template contents?
         template_contents = File.read(template)
         eruby = Erubis::Eruby.new(template_contents)
 
+        render_env = Module.new
+        Dir[File.join(LIB_DIR, '..', 'plugins', '*.rb')].each do |file|
+          render_env.instance_eval(File.read(file))
+        end
+
         out = ""
         # check, will loading all output cause issues with memory size?
         # probably fine - 723 nodes was 350Kb
         node_locations.each do |node|
-          out += parse_yaml(node, eruby, template_contents)
+          out += parse_yaml(node, eruby, render_env)
           p "Parsed #{File.basename(node)}"
         end
 
@@ -88,30 +93,18 @@ module Inventoryware
         end
       end
 
-      def parse_yaml(node, eruby, template_contents)
+      def parse_yaml(node, eruby, render_env)
         begin
-          # `.values[0]` is to ignore the name of the node & just get its data
+          # `.values[0]` ignores the name of the node & gets just its data
           hash = YAML.load_file(node).values[0]
         rescue Psych::SyntaxError
           puts "Error: parsing yaml in #{node} - aborting"
           exit
         end
 
-        #TODO do we need to generate the entire context for each node?
-        ctx = gen_ctx_with_plugins(hash, template_contents)
-        eruby.result(ctx)
-      end
-
-      def gen_ctx_with_plugins(hash, template)
-        render_env = Module.new do
-          def hash
-            hash
-          end
-        end
-        Dir[File.join(LIB_DIR, '..', 'plugins', '*.rb')].each do |file|
-          render_env.instance_eval(File.read(file))
-        end
         ctx = render_env.instance_eval { binding }
+
+        return eruby.result(ctx)
       end
     end
   end

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -68,6 +68,10 @@ module Inventoryware
       end
 
       def output(node_locations, template, out_file)
+        node_locations = node_locations.sort_by { |location|
+          File.basename(location)
+        }
+
         # TODO verify template contents?
         template_contents = File.read(template)
         eruby = Erubis::Eruby.new(template_contents)

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -16,31 +16,72 @@ module Inventoryware
         ctx = render_env.instance_eval { binding }
       end
 
+      def find_all_nodes()
+        node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
+        if node_locations.empty?
+          p "Error: No node data found in #{YAML_DIR}"
+          exit
+        end
+        #TODO sort node_locations?
+        return node_locations
+      end
+
+      def find_nodes(nodes)
+        node_locations = []
+        nodes.each do |node|
+          node_yaml = "#{node}.yaml"
+          node_yaml_location = File.join(YAML_DIR, node_yaml)
+          unless check_file_readable?(node_yaml_location)
+            puts "Error: File #{node_yaml} not found within #{File.expand_path(YAML_DIR)}"
+            exit
+          end
+          node_locations.append(node_yaml_location)
+        end
+        return node_locations
+      end
+
+      def output(node_locations, template, out_file)
+        # TODO verify template contents?
+        template_contents = File.read(template)
+        eruby = Erubis::Eruby.new(template_contents)
+
+        out = ""
+        # check, will loading all output cause issues with memory size?
+        # probably fine - 723 nodes was 350Kb
+        node_locations.each do |node|
+          begin
+            # `.values[0]` it ignore the name of the node & just get its data
+            hash = YAML.load_file(node).values[0]
+          rescue Psych::SyntaxError
+            puts "Error: parsing yaml in #{node} - aborting"
+            exit
+          end
+
+          #TODO do we need to generate the entire context for each node
+          ctx = gen_ctx_with_plugins(hash, template_contents)
+          out += eruby.result(ctx)
+          p "Parsed #{File.basename(node)}"
+        end
+
+        File.open(out_file, 'w') do |file|
+          file.write(out)
+        end
+      end
+
       def run
-        unless @argv.length == 2
-          puts "Error: 'node' and 'template' should be the only arguments"
+        if @options.all and not @argv.length == 1
+          puts "Error: 'template' should be the only argument - all nodes are being parsed."
+          exit
+        elsif not @options.all and @argv.length < 2
+          puts "Error: Please provide a template and at least one node."
           exit
         end
 
-        node = @argv[0]
-        template = @argv[1]
+        template = @argv[0]
+        nodes = @argv[1..-1]
 
-        unless File.file?(template) and File.readable?(template)
+        unless check_file_readable?(template)
           puts "Error: Template at #{template} inaccessible"
-          exit
-        end
-
-        node_yaml = "#{node}.yaml"
-        node_yaml_location = File.join(YAML_DIR, node_yaml)
-        unless check_file?(node_yaml_location)
-          puts "Error: File #{node_yaml} not found within #{File.expand_path(YAML_DIR)}"
-          exit
-        end
-
-        begin
-          hash = YAML.load_file(node_yaml_location)[node]
-        rescue Psych::SyntaxError
-          puts "Error: parsing yaml in #{node_yaml_location} - aborting"
           exit
         end
 
@@ -55,17 +96,16 @@ module Inventoryware
           out_file = @options.location
         else
           exit_unless_dir(OUTPUT_DIR)
-          template_out_name = "#{node}_#{File.basename(template)}"
+          template_out_name = "#{File.basename(template)}"
           out_file = File.join(OUTPUT_DIR, template_out_name)
         end
 
-        # output
-        # TODO verify template contents?
-        template_contents = File.read(template)
-        eruby = Erubis::Eruby.new(template_contents)
-        File.open(out_file, 'w') do |file|
-          file.write(eruby.result(gen_ctx_with_plugins(hash, template_contents)))
-        end
+        output(@options.all ? find_all_nodes() : find_nodes(nodes),
+               template,
+               out_file
+              )
+
+      #TODO encapsulate
       end
     end
   end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -51,6 +51,8 @@ module Inventoryware
   OUTPUT_DIR = File.join(LIB_DIR, '../store')
   YAML_DIR = File.join(OUTPUT_DIR, 'yaml')
   REQ_FILES = ["lshw-xml", "lsblk-a-P"]
+  OTHER_FILES = []
+  ALL_FILES = REQ_FILES + OTHER_FILES
 
   program :name, 'Inventoryware'
   program :version, '0.0.1'

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -81,10 +81,11 @@ module Inventoryware
   end
 
   command :render do |c|
-    cli_syntax(c, 'NODE TEMPLATE')
-    c.description = "Render a node's data as an eRuby template"
+    cli_syntax(c, 'TEMPLATE NODE(S)')
+    c.description = "Render nodes' data as an eRuby template"
     c.option '-l', '--location LOCATION',
         "Output the rendered template to the specified location"
+    c.option '--all', "Render all data in #{YAML_DIR}"
     action(c, Commands::Render)
   end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -20,8 +20,12 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
+def check_zip_exists?(path)
+  (File.file?(path) && check_zip?(path))
+end
+
 def check_zip?(path)
-  (File.file?(path) && File.extname(path) == ".zip")
+  File.extname(path) == ".zip"
 end
 
 def check_file_writable?(path)
@@ -40,7 +44,7 @@ end
 def exit_unless_dir(path)
   unless File.directory?(path)
     puts "Error: Directory #{File.expand_path(path)} not found - please create "\
-      "it before contining."
+      "it before continuing."
     exit
   end
   return true

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -29,12 +29,19 @@ def check_zip?(path)
 end
 
 def check_file_writable?(path)
-  return false unless check_file?(path)
-  return false if File.exists?(path) and not File.writable?(path)
+  return false unless check_file_readable?(path)
+  return false unless File.writable?(path)
   return true
 end
 
-def check_file?(path)
+def check_file_readable?(path)
+  return false unless check_file_location?(path)
+  return false unless File.exists?(path)
+  return false unless File.readable?(path)
+  return true
+end
+
+def check_file_location?(path)
   return false if File.directory?(path)
   return false unless File.directory?(File.dirname(path))
   return false if File.exists?(path) and not File.readable?(path)

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -29,8 +29,8 @@ def check_zip?(path)
 end
 
 def check_file_writable?(path)
-  return false unless check_file_readable?(path)
-  return false unless File.writable?(path)
+  return false unless check_file_location?(path)
+  return false if File.exist?(path) and not File.writable?(path)
   return true
 end
 


### PR DESCRIPTION
Based on #20 

Closes #22 and #21 

Implements batch commands. Now, if the location specified when `parse`ing is a directory, all zips in the location will be processed. For each of these zips any nested zips will be recursively expanded and processed. Any files sibling to a zip will be ignored so nodes' information should only be contained in bottom level .zips.

Changes `render` syntax to:
`render TEMPLATE [NODES | --all]`
Such that 1 or more nodes can be consecutively specified or `-all` can be passed so that all nodes' data in the yaml directory will be processed. These will be sorted by nodename.

Additionally the output for parsing has been changed to satisfy #21 

Also contains some refactoring.