### PR TITLE
Feat/gather groups

### DIFF
--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -118,7 +118,13 @@ module Inventoryware
 
         hash = {}
         hash['Name'] = node_name
-        #TODO find which format the groups will be specifed in and scrub them
+        if file_locations['groups']
+          groups_hash = YAML.load(File.read(file_locations['groups']))
+          hash['groups'] = {
+            'Primary Group' => groups_hash['primary_group'],
+            'Secondary Groups' => groups_hash['secondary_groups'].split(',')
+          }
+        end
         # extract data from lshw
         hash['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))
         # extract data from lsblk

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -50,7 +50,7 @@ module Inventoryware
   LIB_DIR = File.dirname(__FILE__)
   YAML_DIR = File.join(LIB_DIR, '../store')
   REQ_FILES = ["lshw-xml", "lsblk-a-P"]
-  OTHER_FILES = []
+  OTHER_FILES = ["groups"]
   ALL_FILES = REQ_FILES + OTHER_FILES
 
   program :name, 'Inventoryware'

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -1,8 +1,8 @@
 <%= hash['Name'] %>:
   name: <%= hash['Name'] %>
-  primary_group: <%= hash['Primary Group'] %>
+  primary_group: <%= hash['groups']['Primary Group'] %>
   secondary_groups:
-  <% hash['Secondary Groups']&.each do |grp| %>
+  <% hash['groups']['Secondary Groups']&.each do |grp| %>
     <%= "- #{grp}" %>
   <% end %>
 


### PR DESCRIPTION
Based on #24 

Fixes #14 

Uses new gathering scripts to input groups if they exist in the .zip. Looks for yaml file named `groups` (as the script produces)