### PR TITLE
Use stderr for all output messages

### DIFF
--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -6,7 +6,7 @@ module Inventoryware
     class Parse < Command
       def run
         unless @argv.length() == 1
-          p "Error: The data source should be the only argument."
+          $stderr.puts "Error: The data source should be the only argument."
           exit
         end
 
@@ -47,7 +47,7 @@ module Inventoryware
           contents = [data_source]
         end
         if contents.empty?
-          p "No .zip files found at #{data_source}"
+          $stderr.puts "No .zip files found at #{data_source}"
           exit
         end
         return contents
@@ -99,20 +99,20 @@ module Inventoryware
 
       def process_dir(dir)
         node_name = File.basename(dir)
-        p "Importing #{node_name}.zip"
+        $stderr.puts "Importing #{node_name}.zip"
 
         invalid = false
         file_locations = {}
         ALL_FILES.each do |file|
           file_locations[file] = Dir.glob(File.join(dir, "#{file}*"))&.first
           if not file_locations[file] and REQ_FILES.include?(file)
-            p "Warning: File #{file} required in #{node_name}.zip but not found."
+            $stderr.puts "Warning: File #{file} required in #{node_name}.zip but not found."
             invalid = true
           end
         end
 
         if invalid
-          p "Skipping #{node_name}.zip"
+          $stderr.puts "Skipping #{node_name}.zip"
           return false
         end
 
@@ -138,12 +138,13 @@ module Inventoryware
         yaml_out_name = "#{hash['Name']}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)
         unless check_file_writable?(out_file)
-          p "Error: output file #{out_file} not accessible - aborting"
+          $stderr.puts "Error: output file #{out_file} not accessible "\
+            "- aborting"
           exit
         end
         yaml_hash = {hash['Name'] => hash}
         File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
-        p "#{name}.zip imported to #{File.expand_path(out_file)}"
+        $stderr.puts "#{name}.zip imported to #{File.expand_path(out_file)}"
       end
 
     end

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -6,10 +6,12 @@ module Inventoryware
     class Render < Command
       def run
         if @options.all and not @argv.length == 1
-          puts "Error: 'template' should be the only argument - all nodes are being parsed."
+          $stderr.puts "Error: 'template' should be the only argument - all "\
+            "nodes are being parsed."
           exit
         elsif not @options.all and @argv.length < 2
-          puts "Error: Please provide a template and at least one node."
+          $stderr.puts "Error: Please provide a template and at least one "\
+            "node."
           exit
         end
 
@@ -17,7 +19,7 @@ module Inventoryware
         nodes = @argv[1..-1]
 
         unless check_file_readable?(template)
-          puts "Error: Template at #{template} inaccessible"
+          $stderr.puts "Error: Template at #{template} inaccessible"
           exit
         end
 
@@ -27,7 +29,7 @@ module Inventoryware
         #   execution - it may be that this would be better changed
         if @options.location
           unless check_file_writable?(@options.location)
-            puts "Error: Invalid destination '#{@options.location}'"
+            $stderr.puts "Error: Invalid destination '#{@options.location}'"
             exit
           end
           out_file = @options.location
@@ -43,7 +45,7 @@ module Inventoryware
       def find_all_nodes()
         node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
         if node_locations.empty?
-          p "Error: No node data found in #{YAML_DIR}"
+          $stderr.puts "Error: No node data found in #{YAML_DIR}"
           exit
         end
         return node_locations
@@ -55,7 +57,8 @@ module Inventoryware
           node_yaml = "#{node}.yaml"
           node_yaml_location = File.join(YAML_DIR, node_yaml)
           unless check_file_readable?(node_yaml_location)
-            puts "Error: File #{node_yaml} not found within #{File.expand_path(YAML_DIR)}"
+            $stderr.puts "Error: File #{node_yaml} not found within "\
+              "#{File.expand_path(YAML_DIR)}"
             exit
           end
           node_locations.append(node_yaml_location)
@@ -92,6 +95,7 @@ module Inventoryware
             file.write(out)
           end
         else
+          # '$stdout' here is just to be explicit - for clarity
           $stdout.puts out
         end
       end
@@ -101,7 +105,7 @@ module Inventoryware
           # `.values[0]` ignores the name of the node & gets just its data
           hash = YAML.load_file(node).values[0]
         rescue Psych::SyntaxError
-          puts "Error: parsing yaml in #{node} - aborting"
+          $stderr.puts "Error: parsing yaml in #{node} - aborting"
           exit
         end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -50,8 +50,8 @@ end
 
 def exit_unless_dir(path)
   unless File.directory?(path)
-    puts "Error: Directory #{File.expand_path(path)} not found - please create "\
-      "it before continuing."
+    $stderr.puts "Error: Directory #{File.expand_path(path)} not found - "\
+      "please create it before continuing."
     exit
   end
   return true


### PR DESCRIPTION
Small change to allow rendered templates to be safely & consistently be captured from stdout.
The changes to the parse command are, in actuality, unnecessary as there would be no purpose to capturing the stdout of the program ran for parsing. However they've been made for consistency.