### PR TITLE
group parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The commands' syntax is as follows:
 ```
 parse DATA_LOCATION
 
-render TEMPLATE_LOCATION [NODE_NAME(S) | --all] [-l DESTINATION]
+render TEMPLATE_LOCATION [NODE_NAME(S) -g GROUPS,HERE | --all] [-l DESTINATION]
 ```
 
 The `parse` command processes zips at the specified location into yaml stored in the `store/`
@@ -18,8 +18,9 @@ file will be processed if it exists.
 
 The `render` command fills eRuby templates using stored data. The first argument is the template to
 fill then either n nodes follow or `--all` can be passed to process all .yaml files in the `store/`
-directory. The output will be passed to stdout unless a destination is specified with the `-l`
-option.
+directory. Additionally groups can be selected with the `-g` option in which case all nodes in the
+specified groups will be processed.
+The output will be passed to stdout unless a destination is specified with the `-l` option.
 
 ## Installation
 

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -119,13 +119,10 @@ module Inventoryware
         node_data = {}
         node_data['Name'] = node_name
         node_data['groups'] = {}
-        node_data['groups']['Primary Group'] = nil
-        node_data['groups']['Secondary Groups'] = []
+        node_data['groups']['primary_group'] = nil
+        node_data['groups']['secondary_groups'] = nil
         if file_locations['groups']
-          groups_hash = YAML.load(File.read(file_locations['groups']))
-          node_data['groups']['Primary Group'] = groups_hash['primary_group']
-          sec_groups = groups_hash['secondary_groups'].split(',')
-          node_data['groups']['Secondary Groups'] = sec_groups
+          node_data['groups'] = YAML.load(File.read(file_locations['groups']))
         end
         # extract data from lshw
         node_data['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -66,9 +66,9 @@ module Inventoryware
           found = []
           File.open(location) do |file|
             contents = file.read
-            m = contents.match(/primary_group: (.*^?)/)[1]
+            m = contents.match(/primary_group: (.*?)$/)[1]
             found.append(m) unless m.empty?
-            m = contents.match(/secondary_groups: (.*^?)/)[1]
+            m = contents.match(/secondary_groups: (.*?)$/)[1]
             found = found + (m.split(',')) unless m.empty?
           end
           unless (found & groups).empty?

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -5,11 +5,11 @@ module Inventoryware
   module Commands
     class Render < Command
       def run
-        if (@options.group or @options.all) and not @argv.length == 1
-          $stderr.puts "Error: 'template' should be the only argument - set "\
+        if @options.all and not @argv.length == 1
+          $stderr.puts "Error: 'template' should be the only argument - all "\
             "nodes are being parsed."
           exit
-        elsif not (@options.all or @options.group) and @argv.length < 2
+        elsif not @options.group and @argv.length < 2
           $stderr.puts "Error: Please provide a template and at least one "\
             "node."
           exit
@@ -37,10 +37,14 @@ module Inventoryware
 
         if @options.all
           node_locations = find_all_nodes
-        elsif @options.group
-          node_locations = find_nodes_in_groups(@options.group.split(','))
         else
-          node_locations = find_nodes(nodes)
+          if nodes
+            single_nodes = find_nodes(nodes)
+          end
+          if @options.group
+            groups_nodes = find_nodes_in_groups(@options.group.split(','))
+          end
+          node_locations = single_nodes + groups_nodes
         end
 
         output(node_locations, template, out_file)

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -99,6 +99,8 @@ module Inventoryware
       end
 
       def output(node_locations, template, out_file)
+        node_locations = node_locations.uniq
+
         node_locations = node_locations.sort_by do |location|
           File.basename(location)
         end

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -5,10 +5,12 @@ module Inventoryware
   module Commands
     class Render < Command
       def run
-        if @options.all and not @argv.length == 1
-          $stderr.puts "Error: 'template' should be the only argument - all "\
-            "nodes are being parsed."
-          exit
+        if @options.all
+          unless @argv.length == 1
+            $stderr.puts "Error: 'template' should be the only argument - all "\
+              "nodes are being parsed."
+            exit
+          end
         elsif not @options.group and @argv.length < 2
           $stderr.puts "Error: Please provide a template and at least one "\
             "node."

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -83,6 +83,7 @@ module Inventoryware
       end
 
       def find_nodes(nodes)
+        nodes = expand_node_ranges(nodes)
         node_locations = []
         nodes.each do |node|
           node_yaml = "#{node}.yaml"

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -85,6 +85,8 @@ module Inventoryware
     c.option '-l', '--location LOCATION',
         "Output the rendered template to the specified location"
     c.option '--all', "Render all data in #{File.expand_path(YAML_DIR)}"
+    c.option '-g', '--group GROUP',
+      "Render all nodes in GROUP, commma-seperate values for multiple groups"
     action(c, Commands::Render)
   end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -66,7 +66,6 @@ def expand_node_ranges(nodes)
       suffix = m[2]
       ranges = suffix.split(',')
       ranges.each do |range|
-        p range
         if range.match(/-/)
           num_1, num_2 = range.split('-')
           padding = num_1.match(/^0+/)

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -56,3 +56,34 @@ def exit_unless_dir(path)
   end
   return true
 end
+
+def expand_node_ranges(nodes)
+  new_nodes = []
+  nodes.each do |node|
+    if node.match(/.*\[[0-9]+.*[0-9]+\]$/)
+      m = node.match(/^(.*)\[(.*)\]$/)
+      prefix = m[1]
+      suffix = m[2]
+      ranges = suffix.split(',')
+      ranges.each do |range|
+        p range
+        if range.match(/-/)
+          num_1, num_2 = range.split('-')
+          padding = num_1.match(/^0+/)
+          unless num_1 <= num_2
+            $stderr.puts "Invalid node range #{range}"
+            exit
+          end
+          (num_1.to_i .. num_2.to_i).each do |num|
+            new_nodes.push(sprintf("%s%0#{padding.to_s.length + 1}d", prefix, num))
+          end
+        else
+          new_nodes << "#{prefix}#{range}"
+        end
+      end
+      nodes.delete(node)
+    end
+  end
+  nodes = nodes + new_nodes
+  return nodes
+end

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -1,7 +1,7 @@
 <%= node_data['Name'] %>:
   name: <%= node_data['Name'] %>
-  primary_group: <%= node_data['groups']['Primary Group'] %>
-  secondary_groups: <%= node_data['groups']['Secondary Groups'].join(',') %>
+  primary_group: <%= node_data['groups']['primary_group'] %>
+  secondary_groups: <%= node_data['groups']['secondary_groups'] %>
   info: |
     # System
 


### PR DESCRIPTION
Closes #28 

Adds pseudo-genders functionality

Rendering can now be performed on a group basis. The `render` command takes a `--group/-g` argument and all nodes in `store/` will be searched for membership in its values. Comma separated lists are supported.

Additionally nodes used as arguments for render can now be ranges in the form `node[001-15,017,048-60]`

Duplicates will be removed before processing.