### PR TITLE
Feat/non standard hw

### DIFF
--- a/lib/commands/add_location.rb
+++ b/lib/commands/add_location.rb
@@ -1,0 +1,40 @@
+
+module Inventoryware
+  module Commands
+    class AddLocation < Command
+      def run
+        other_args = []
+        nodes = Utils::resolve_node_options(@argv, @options, other_args)
+        node_locations = Utils::select_nodes(nodes, @options)
+
+        fields = {
+          'site' => nil,
+          'room' => nil,
+          'rack' => nil,
+          'unit' => nil,
+          'chassis' => nil,
+          'slot' => nil
+        }
+
+        fields.keys.each do |field|
+          p "Enter a #{field} or press enter to skip"
+          value = STDIN.gets.chomp
+          fields[field] = value if value
+        end
+
+        node_locations.each do |location|
+          node_data = Utils.read_node_yaml(location).values[0]
+          fields.each do |key, value|
+            unless value.empty?
+              node_data['mutable'][key] = value
+            end
+            if value.empty? and node_data['mutable'].key?(key)
+              node_data['mutable'].delete(key)
+            end
+          end
+          Utils::output_node_yaml(node_data, location)
+        end
+      end
+    end
+  end
+end

--- a/lib/commands/add_location.rb
+++ b/lib/commands/add_location.rb
@@ -28,9 +28,6 @@ module Inventoryware
             unless value.empty?
               node_data['mutable'][key] = value
             end
-            if value.empty? and node_data['mutable'].key?(key)
-              node_data['mutable'].delete(key)
-            end
           end
           Utils::output_node_yaml(node_data, location)
         end

--- a/lib/commands/edit.rb
+++ b/lib/commands/edit.rb
@@ -1,0 +1,22 @@
+
+module Inventoryware
+  module Commands
+    class Edit < Command
+      def run
+        other_args = ["field", "value"]
+        nodes = Utils::resolve_node_options(@argv, @options, other_args)
+
+        #TODO DRY up? field and value are defined twice
+        field, value = @argv[0..1]
+
+        node_locations = Utils::select_nodes(nodes, @options)
+
+        node_locations.each do |location|
+          node_data = Utils.read_node_yaml(location).values[0]
+          node_data['mutable'][field] = value
+          Utils::output_node_yaml(node_data, location)
+        end
+      end
+    end
+  end
+end

--- a/lib/commands/modify.rb
+++ b/lib/commands/modify.rb
@@ -3,17 +3,26 @@ module Inventoryware
   module Commands
     class Modify < Command
       def run
-        other_args = ["field", "value"]
+        other_args = ["modification"]
         nodes = Utils::resolve_node_options(@argv, @options, other_args)
 
-        #TODO DRY up? field and value are defined twice
-        field, value = @argv[0..1]
+        #TODO DRY up? modification is defined twice
+        modification = @argv[0]
+        unless modification.match(/=/)
+          $stderr.puts "Invalid modification - must contain an '='"
+          exit
+        end
+        field, value = modification.split('=')
 
         node_locations = Utils::select_nodes(nodes, @options)
 
         node_locations.each do |location|
           node_data = Utils.read_node_yaml(location).values[0]
-          node_data['mutable'][field] = value
+          if value
+            node_data['mutable'][field] = value
+          else
+            node_data['mutable'].delete(field)
+          end
           Utils::output_node_yaml(node_data, location)
         end
       end

--- a/lib/commands/modify.rb
+++ b/lib/commands/modify.rb
@@ -14,10 +14,20 @@ module Inventoryware
         end
         field, value = modification.split('=')
 
-        node_locations = Utils::select_nodes(nodes, @options)
+        node_locations = Utils::select_nodes(nodes,
+                                             @options,
+                                             return_missing = true)
 
         node_locations.each do |location|
-          node_data = Utils.read_node_yaml(location).values[0]
+          if Utils::check_file_readable?(location)
+            node_data = Utils.read_node_yaml(location).values[0]
+          else
+            node_data = {
+              'name' => File.basename(location, '.yaml'),
+              'mutable' => {},
+              'imported' => false
+            }
+          end
           if value
             node_data['mutable'][field] = value
           else

--- a/lib/commands/modify.rb
+++ b/lib/commands/modify.rb
@@ -1,7 +1,7 @@
 
 module Inventoryware
   module Commands
-    class Edit < Command
+    class Modify < Command
       def run
         other_args = ["field", "value"]
         nodes = Utils::resolve_node_options(@argv, @options, other_args)

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -129,21 +129,11 @@ module Inventoryware
         # extract data from lsblk
         node_data['lsblk'] = LsblkParser.new(file_locations['lsblk-a-P']).hashify()
 
-        output_yaml(node_data)
-      end
-
-      def output_yaml(node_data)
-        node_name = node_data['name']
         Utils::exit_unless_dir(YAML_DIR)
         yaml_out_name = "#{node_name}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)
-        unless Utils::check_file_writable?(out_file)
-          $stderr.puts "Error: output file #{out_file} not accessible "\
-            "- aborting"
-          exit
-        end
-        yaml_hash = {node_name => node_data}
-        File.open(out_file, 'w') { |file| file.write(yaml_hash.to_yaml) }
+        Utils::output_node_yaml(node_data, out_file)
+
         $stderr.puts "#{node_name}.zip imported to "\
           "#{File.expand_path(out_file)}"
       end

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -43,7 +43,7 @@ module Inventoryware
         contents = []
         if File.directory?(data_source)
           contents = Dir.glob(File.join(data_source, "**/*.zip"))
-        elsif check_zip_exists?(data_source)
+        elsif Utils::check_zip_exists?(data_source)
           contents = [data_source]
         end
         if contents.empty?
@@ -134,10 +134,10 @@ module Inventoryware
 
       def output_yaml(node_data)
         node_name = node_data['name']
-        exit_unless_dir(YAML_DIR)
+        Utils::exit_unless_dir(YAML_DIR)
         yaml_out_name = "#{node_name}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)
-        unless check_file_writable?(out_file)
+        unless Utils::check_file_writable?(out_file)
           $stderr.puts "Error: output file #{out_file} not accessible "\
             "- aborting"
           exit

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -117,7 +117,7 @@ module Inventoryware
         end
 
         node_data = {}
-        node_data['Name'] = node_name
+        node_data['name'] = node_name
         node_data['groups'] = {}
         node_data['groups']['primary_group'] = nil
         node_data['groups']['secondary_groups'] = nil
@@ -133,7 +133,7 @@ module Inventoryware
       end
 
       def output_yaml(node_data)
-        node_name = node_data['Name']
+        node_name = node_data['name']
         exit_unless_dir(YAML_DIR)
         yaml_out_name = "#{node_name}.yaml"
         out_file = File.join(YAML_DIR, yaml_out_name)

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -118,11 +118,11 @@ module Inventoryware
 
         node_data = {}
         node_data['name'] = node_name
-        node_data['groups'] = {}
-        node_data['groups']['primary_group'] = nil
-        node_data['groups']['secondary_groups'] = nil
+        node_data['mutable'] = {}
+        node_data['mutable']['primary_group'] = nil
+        node_data['mutable']['secondary_groups'] = nil
         if file_locations['groups']
-          node_data['groups'] = YAML.load(File.read(file_locations['groups']))
+          node_data['mutable'] = YAML.load(File.read(file_locations['groups']))
         end
         # extract data from lshw
         node_data['lshw'] = XmlHasher.parse(File.read(file_locations['lshw-xml']))

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -5,22 +5,13 @@ module Inventoryware
   module Commands
     class Render < Command
       def run
-        if @options.all
-          unless @argv.length == 1
-            $stderr.puts "Error: 'template' should be the only argument - all "\
-              "nodes are being parsed."
-            exit
-          end
-        elsif not @options.group and @argv.length < 2
-          $stderr.puts "Error: Please provide a template and at least one "\
-            "node."
-          exit
-        end
+        other_args = ["template"]
+        nodes = Utils::resolve_node_options(@argv, @options, other_args)
 
+        #TODO DRY up definition of arguments? template is declared twice
         template = @argv[0]
-        nodes = @argv[1..-1]
 
-        unless check_file_readable?(template)
+        unless Utils::check_file_readable?(template)
           $stderr.puts "Error: Template at #{template} inaccessible"
           exit
         end
@@ -30,78 +21,15 @@ module Inventoryware
         # decided against creating location if it did not exist as it requires sudo
         #   execution - it may be that this would be better changed
         if @options.location
-          unless check_file_writable?(@options.location)
+          unless Utils::check_file_writable?(@options.location)
             $stderr.puts "Error: Invalid destination '#{@options.location}'"
             exit
           end
           out_file = @options.location
         end
 
-        if @options.all
-          node_locations = find_all_nodes
-        else
-          if nodes
-            single_nodes = find_nodes(nodes)
-          end
-          if @options.group
-            groups_nodes = find_nodes_in_groups(@options.group.split(','))
-          end
-          node_locations = single_nodes + groups_nodes
-        end
-
+        node_locations = Utils::select_nodes(nodes, @options)
         output(node_locations, template, out_file)
-      end
-
-      private
-      def find_all_nodes()
-        node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
-        if node_locations.empty?
-          $stderr.puts "Error: No node data found in #{YAML_DIR}"
-          exit
-        end
-        return node_locations
-      end
-
-      # this quite an intensive method of way to go about searching the yaml
-      # each file is converted to a sting and then searched
-      # seems fine as it stands but if speed becomes an issue could stand to
-      #   be changed
-      def find_nodes_in_groups(groups)
-        nodes = []
-        find_all_nodes().each do |location|
-          found = []
-          File.open(location) do |file|
-            contents = file.read
-            m = contents.match(/primary_group: (.*?)$/)[1]
-            found.append(m) unless m.empty?
-            m = contents.match(/secondary_groups: (.*?)$/)[1]
-            found = found + (m.split(',')) unless m.empty?
-          end
-          unless (found & groups).empty?
-            nodes.append(location)
-          end
-        end
-        if nodes.empty?
-          $stderr.puts "Error: no nodes in #{groups.join(', ')} found - exiting"
-          exit
-        end
-        return nodes
-      end
-
-      def find_nodes(nodes)
-        nodes = expand_node_ranges(nodes)
-        node_locations = []
-        nodes.each do |node|
-          node_yaml = "#{node}.yaml"
-          node_yaml_location = File.join(YAML_DIR, node_yaml)
-          unless check_file_readable?(node_yaml_location)
-            $stderr.puts "Error: File #{node_yaml} not found within "\
-              "#{File.expand_path(YAML_DIR)}"
-            exit
-          end
-          node_locations.append(node_yaml_location)
-        end
-        return node_locations
       end
 
       def output(node_locations, template, out_file)

--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -73,13 +73,8 @@ module Inventoryware
       end
 
       def parse_yaml(node_location, eruby, render_env)
-        begin
-          # `.values[0]` ignores the name of the node & gets just its data
-          node_data = YAML.load_file(node_location).values[0]
-        rescue Psych::SyntaxError
-          $stderr.puts "Error: parsing yaml in #{node_location} - aborting"
-          exit
-        end
+        # `.values[0]` ignores the name of the node & gets just its data
+        node_data = Utils::read_node_yaml(node_location).values[0]
         render_env.instance_variable_set(:@node_data, node_data)
         ctx = render_env.instance_eval { binding }
 

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -73,6 +73,13 @@ module Inventoryware
     command.syntax = s
   end
 
+  def self.add_node_options(command)
+    command.option '--all', "Render all data in #{File.expand_path(YAML_DIR)}"
+    command.option '-g', '--group GROUP',
+      "Render all nodes in GROUP, commma-seperate values for multiple groups"
+    return command
+  end
+
   command :parse do |c|
     cli_syntax(c, 'DATA_SOURCE')
     c.description = 'Parse hardware information into yaml'
@@ -84,10 +91,15 @@ module Inventoryware
     c.description = "Render nodes' data as an eRuby template"
     c.option '-l', '--location LOCATION',
         "Output the rendered template to the specified location"
-    c.option '--all', "Render all data in #{File.expand_path(YAML_DIR)}"
-    c.option '-g', '--group GROUP',
-      "Render all nodes in GROUP, commma-seperate values for multiple groups"
+    c = add_node_options(c)
     action(c, Commands::Render)
+  end
+
+  command :edit do |c|
+    cli_syntax(c, 'FIELD VALUE NODE(S)')
+    c.description = "Edit some nodes' data"
+    c = add_node_options(c)
+    action(c, Commands::Edit)
   end
 
 end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -102,8 +102,7 @@ module Inventoryware
     action(c, Commands::Modify)
   end
 
-  command :add_location do |c|
-    c.name = 'add-location'
+  command :'add-location' do |c|
     cli_syntax(c, 'NODE(S)')
     c.description = "Specify some nodes' location - can also be"\
       " acheived through modify"

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -96,7 +96,7 @@ module Inventoryware
   end
 
   command :modify do |c|
-    cli_syntax(c, 'FIELD VALUE NODE(S)')
+    cli_syntax(c, 'FIELD=VALUE NODE(S)')
     c.description = "Modify some nodes' data"
     c = add_node_options(c)
     action(c, Commands::Modify)

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -102,4 +102,12 @@ module Inventoryware
     action(c, Commands::Modify)
   end
 
+  command :add_location do |c|
+    c.name = 'add-location'
+    cli_syntax(c, 'NODE(S)')
+    c.description = "Specify some nodes' location - can also be"\
+      " acheived through modify"
+    c = add_node_options(c)
+    action(c, Commands::AddLocation)
+  end
 end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -95,11 +95,11 @@ module Inventoryware
     action(c, Commands::Render)
   end
 
-  command :edit do |c|
+  command :modify do |c|
     cli_syntax(c, 'FIELD VALUE NODE(S)')
-    c.description = "Edit some nodes' data"
+    c.description = "Modify some nodes' data"
     c = add_node_options(c)
-    action(c, Commands::Edit)
+    action(c, Commands::Modify)
   end
 
 end

--- a/lib/lsblk_parser.rb
+++ b/lib/lsblk_parser.rb
@@ -20,50 +20,52 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
-# Only designed on lsblk output with the -a (all) and 
+# Only designed on lsblk output with the -a (all) and
 # -P (key/value pairs) options
-class LsblkParser
-  def initialize(file)
-    f = File.open(file)
-    f_rows = f.read.split("\n")
-    f.close
-    @rows = f_rows.map { |row| LsblkRow.new(row) }
-  end
+module Inventoryware
+  class LsblkParser
+    def initialize(file)
+      f = File.open(file)
+      f_rows = f.read.split("\n")
+      f.close
+      @rows = f_rows.map { |row| LsblkRow.new(row) }
+    end
 
-  def hashify()
-    blk_hash = {}
-    @rows.each do |row|
-      if !blk_hash[row.type]
-        blk_hash[row.type] = {}
+    def hashify()
+      blk_hash = {}
+      @rows.each do |row|
+        if !blk_hash[row.type]
+          blk_hash[row.type] = {}
+        end
+        blk_hash[row.type][row.name] = {
+          'MAJ:MIN' => row.maj_min,
+          'RM' => row.rm,
+          'SIZE' => row.size,
+          'RO' => row.ro,
+          'MOUNTPOINT' => row.mountpoint
+        }
       end
-      blk_hash[row.type][row.name] = {
-        'MAJ:MIN' => row.maj_min,
-        'RM' => row.rm,
-        'SIZE' => row.size,
-        'RO' => row.ro,
-        'MOUNTPOINT' => row.mountpoint
-      }
-    end
-    return blk_hash
-  end
-
-  class LsblkRow
-    attr_reader :name, :type, :size, :maj_min, :rm, :ro, :mountpoint
-
-    def initialize(row)
-      @row = row
-      @name = find_value('NAME')
-      @type = find_value('TYPE')
-      @size = find_value('SIZE')
-      @maj_min = find_value('MAJ:MIN')
-      @rm = find_value('RM')
-      @ro = find_value('RO')
-      @mountpoint = find_value('MOUNTPOINT')
-
+      return blk_hash
     end
 
-    def find_value(key)
-      /#{key}="(.*?)"/.match(@row)[1]
+    class LsblkRow
+      attr_reader :name, :type, :size, :maj_min, :rm, :ro, :mountpoint
+
+      def initialize(row)
+        @row = row
+        @name = find_value('NAME')
+        @type = find_value('TYPE')
+        @size = find_value('SIZE')
+        @maj_min = find_value('MAJ:MIN')
+        @rm = find_value('RM')
+        @ro = find_value('RO')
+        @mountpoint = find_value('MOUNTPOINT')
+
+      end
+
+      def find_value(key)
+        /#{key}="(.*?)"/.match(@row)[1]
+      end
     end
   end
 end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -111,6 +111,26 @@ module Inventoryware
       nodes = argv[other_args.length..-1]
     end
 
+    def self.read_node_yaml(node_location)
+      begin
+        node_data = YAML.load_file(node_location)
+      rescue Psych::SyntaxError
+        $stderr.puts "Error: parsing yaml in #{node_location} - aborting"
+        exit
+      end
+      return node_data
+    end
+
+    def self.output_node_yaml(node_data, location)
+      unless check_file_writable?(location)
+        $stderr.puts "Error: output file #{location} not accessible "\
+          "- aborting"
+        exit
+      end
+      yaml_hash = {node_data['name'] => node_data}
+      File.open(location, 'w') { |file| file.write(yaml_hash.to_yaml) }
+    end
+
     def self.select_nodes(nodes, options)
       node_locations = []
       if options.all

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -84,23 +84,40 @@ module Inventoryware
       return nodes
     end
 
+    #TODO make this method less awful
     def self.resolve_node_options(argv, options, other_args)
       arg_str = other_args.join(', ')
+
       if options.all
         unless argv.length == other_args.length
-          $stderr.puts "Error: #{arg_str} should be the only argument(s) - all "\
-            "nodes are being parsed."
-          exit
+          unless other_args.length == 0
+            $stderr.puts "Error: #{arg_str} should be the only argument(s) - "
+              "all nodes are being parsed."
+            exit
+          else
+            $stderr.puts "Error: There should be the no arguments - all "\
+              "nodes are being parsed."
+            exit
+          end
         end
+
       elsif options.group
         if argv.length < other_args.length
           $stderr.puts "Error: please provide #{arg_str}."
           exit
         end
-      elsif argv.length < other_args.length + 1
-        $stderr.puts "Error: Please provide #{arg_str} and at least one "\
-          "node."
-        exit
+
+      else
+        if argv.length < other_args.length + 1
+          unless other_args.length == 0
+            $stderr.puts "Error: Please provide #{arg_str} and at least one "\
+              "node."
+            exit
+          else
+            $stderr.puts "Error: Please provide at least one node."
+            exit
+          end
+        end
       end
 
       nodes = argv[other_args.length..-1]

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -176,8 +176,7 @@ module Inventoryware
         end
       end
       if nodes.empty?
-        $stderr.puts "Error: no nodes in #{groups.join(', ')} found - exiting"
-        exit
+        $stderr.puts "No nodes found in #{groups.join(', ')}."
       end
       return nodes
     end
@@ -189,9 +188,9 @@ module Inventoryware
         node_yaml = "#{node}.yaml"
         node_yaml_location = File.join(YAML_DIR, node_yaml)
         unless check_file_readable?(node_yaml_location)
-          $stderr.puts "Error: File #{node_yaml} not found within "\
+          $stderr.puts "File #{node_yaml} not found within "\
             "#{File.expand_path(YAML_DIR)}"
-          exit
+          next
         end
         node_locations.append(node_yaml_location)
       end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -70,7 +70,10 @@ module Inventoryware
           ranges.each do |range|
             if range.match(/-/)
               num_1, num_2 = range.split('-')
-              padding = num_1.match(/^0+/)
+              # chomp here is in case num_1 consists only of 0's
+              # in that case, e.g. node[000-001], the padding should be 1 char shorter
+              # than all the leading 0s in num_1, e.g. '00'
+              padding = num_1.chomp('0').match(/^0+/)
               unless num_1 <= num_2
                 $stderr.puts "Invalid node range #{range}"
                 exit

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -143,13 +143,13 @@ module Inventoryware
       File.open(location, 'w') { |file| file.write(yaml_hash.to_yaml) }
     end
 
-    def self.select_nodes(nodes, options)
+    def self.select_nodes(nodes, options, return_missing = false)
       node_locations = []
       if options.all
         node_locations = find_all_nodes
       else
         if nodes
-          node_locations.push(*find_nodes(nodes))
+          node_locations.push(*find_nodes(nodes, return_missing = true))
         end
         if options.group
           node_locations.push(*find_nodes_in_groups(options.group.split(',')))
@@ -193,7 +193,7 @@ module Inventoryware
       return nodes
     end
 
-    def self.find_nodes(nodes)
+    def self.find_nodes(nodes, return_missing = false)
       nodes = expand_node_ranges(nodes)
       node_locations = []
       nodes.each do |node|
@@ -202,7 +202,12 @@ module Inventoryware
         unless check_file_readable?(node_yaml_location)
           $stderr.puts "File #{node_yaml} not found within "\
             "#{File.expand_path(YAML_DIR)}"
-          next
+          if return_missing
+            $stderr.puts "Creating..."
+          else
+            $stderr.puts "Skipping"
+            next
+          end
         end
         node_locations.append(node_yaml_location)
       end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -20,69 +20,162 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
-def check_zip_exists?(path)
-  (File.file?(path) && check_zip?(path))
-end
+module Inventoryware
+  module Utils
+    def self.check_zip_exists?(path)
+      (File.file?(path) && check_zip?(path))
+    end
 
-def check_zip?(path)
-  File.extname(path) == ".zip"
-end
+    def self.check_zip?(path)
+      File.extname(path) == ".zip"
+    end
 
-def check_file_writable?(path)
-  return false unless check_file_location?(path)
-  return false if File.exist?(path) and not File.writable?(path)
-  return true
-end
+    def self.check_file_writable?(path)
+      return false unless check_file_location?(path)
+      return false if File.exist?(path) and not File.writable?(path)
+      return true
+    end
 
-def check_file_readable?(path)
-  return false unless check_file_location?(path)
-  return false unless File.exists?(path)
-  return false unless File.readable?(path)
-  return true
-end
+    def self.check_file_readable?(path)
+      return false unless check_file_location?(path)
+      return false unless File.exists?(path)
+      return false unless File.readable?(path)
+      return true
+    end
 
-def check_file_location?(path)
-  return false if File.directory?(path)
-  return false unless File.directory?(File.dirname(path))
-  return false if File.exists?(path) and not File.readable?(path)
-  return true
-end
+    def self.check_file_location?(path)
+      return false if File.directory?(path)
+      return false unless File.directory?(File.dirname(path))
+      return false if File.exists?(path) and not File.readable?(path)
+      return true
+    end
 
-def exit_unless_dir(path)
-  unless File.directory?(path)
-    $stderr.puts "Error: Directory #{File.expand_path(path)} not found - "\
-      "please create it before continuing."
-    exit
-  end
-  return true
-end
+    def self.exit_unless_dir(path)
+      unless File.directory?(path)
+        $stderr.puts "Error: Directory #{File.expand_path(path)} not found - "\
+          "please create it before continuing."
+        exit
+      end
+      return true
+    end
 
-def expand_node_ranges(nodes)
-  new_nodes = []
-  nodes.each do |node|
-    if node.match(/.*\[[0-9]+.*[0-9]+\]$/)
-      m = node.match(/^(.*)\[(.*)\]$/)
-      prefix = m[1]
-      suffix = m[2]
-      ranges = suffix.split(',')
-      ranges.each do |range|
-        if range.match(/-/)
-          num_1, num_2 = range.split('-')
-          padding = num_1.match(/^0+/)
-          unless num_1 <= num_2
-            $stderr.puts "Invalid node range #{range}"
-            exit
+    def self.expand_node_ranges(nodes)
+      new_nodes = []
+      nodes.each do |node|
+        if node.match(/.*\[[0-9]+.*[0-9]+\]$/)
+          m = node.match(/^(.*)\[(.*)\]$/)
+          prefix = m[1]
+          suffix = m[2]
+          ranges = suffix.split(',')
+          ranges.each do |range|
+            if range.match(/-/)
+              num_1, num_2 = range.split('-')
+              padding = num_1.match(/^0+/)
+              unless num_1 <= num_2
+                $stderr.puts "Invalid node range #{range}"
+                exit
+              end
+              (num_1.to_i .. num_2.to_i).each do |num|
+                new_nodes.push(sprintf("%s%0#{padding.to_s.length + 1}d", prefix, num))
+              end
+            else
+              new_nodes << "#{prefix}#{range}"
+            end
           end
-          (num_1.to_i .. num_2.to_i).each do |num|
-            new_nodes.push(sprintf("%s%0#{padding.to_s.length + 1}d", prefix, num))
-          end
-        else
-          new_nodes << "#{prefix}#{range}"
+          nodes.delete(node)
         end
       end
-      nodes.delete(node)
+      nodes = nodes + new_nodes
+      return nodes
+    end
+
+    def self.resolve_node_options(argv, options, other_args)
+      arg_str = other_args.join(', ')
+      if options.all
+        unless argv.length == other_args.length
+          $stderr.puts "Error: #{arg_str} should be the only argument(s) - all "\
+            "nodes are being parsed."
+          exit
+        end
+      elsif options.group
+        if argv.length < other_args.length
+          $stderr.puts "Error: please provide #{arg_str}."
+          exit
+        end
+      elsif argv.length < other_args.length + 1
+        $stderr.puts "Error: Please provide #{arg_str} and at least one "\
+          "node."
+        exit
+      end
+
+      nodes = argv[other_args.length..-1]
+    end
+
+    def self.select_nodes(nodes, options)
+      node_locations = []
+      if options.all
+        node_locations = find_all_nodes
+      else
+        if nodes
+          node_locations.push(*find_nodes(nodes))
+        end
+        if options.group
+          node_locations.push(*find_nodes_in_groups(options.group.split(',')))
+        end
+      end
+      return node_locations
+    end
+
+    private
+    def self.find_all_nodes()
+      node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
+      if node_locations.empty?
+        $stderr.puts "Error: No node data found in #{YAML_DIR}"
+        exit
+      end
+      return node_locations
+    end
+
+    # this quite an intensive method of way to go about searching the yaml
+    # each file is converted to a sting and then searched
+    # seems fine as it stands but if speed becomes an issue could stand to
+    #   be changed
+    def self.find_nodes_in_groups(groups)
+      nodes = []
+      find_all_nodes().each do |location|
+        found = []
+        File.open(location) do |file|
+          contents = file.read
+          m = contents.match(/primary_group: (.*?)$/)[1]
+          found.append(m) unless m.empty?
+          m = contents.match(/secondary_groups: (.*?)$/)[1]
+          found = found + (m.split(',')) unless m.empty?
+        end
+        unless (found & groups).empty?
+          nodes.append(location)
+        end
+      end
+      if nodes.empty?
+        $stderr.puts "Error: no nodes in #{groups.join(', ')} found - exiting"
+        exit
+      end
+      return nodes
+    end
+
+    def self.find_nodes(nodes)
+      nodes = expand_node_ranges(nodes)
+      node_locations = []
+      nodes.each do |node|
+        node_yaml = "#{node}.yaml"
+        node_yaml_location = File.join(YAML_DIR, node_yaml)
+        unless check_file_readable?(node_yaml_location)
+          $stderr.puts "Error: File #{node_yaml} not found within "\
+            "#{File.expand_path(YAML_DIR)}"
+          exit
+        end
+        node_locations.append(node_yaml_location)
+      end
+      return node_locations
     end
   end
-  nodes = nodes + new_nodes
-  return nodes
 end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -70,16 +70,8 @@ module Inventoryware
           ranges.each do |range|
             if range.match(/-/)
               num_1, num_2 = range.split('-')
-              # chomp here is in case num_1 consists only of 0's
-              # in that case, e.g. node[000-001], the padding should be 1 char shorter
-              # than all the leading 0s in num_1, e.g. '00'
-              padding = num_1.chomp('0').match(/^0+/)
-              unless num_1 <= num_2
-                $stderr.puts "Invalid node range #{range}"
-                exit
-              end
               (num_1.to_i .. num_2.to_i).each do |num|
-                new_nodes.push(sprintf("%s%0#{padding.to_s.length + 1}d", prefix, num))
+                new_nodes << "#{prefix}#{num.to_s.rjust(num_1.length, '0')}"
               end
             else
               new_nodes << "#{prefix}#{range}"

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -1,7 +1,7 @@
 <%= node_data['name'] %>:
   name: <%= node_data['name'] %>
-  primary_group: <%= node_data['groups']['primary_group'] %>
-  secondary_groups: <%= node_data['groups']['secondary_groups'] %>
+  primary_group: <%= node_data['mutable']['primary_group'] %>
+  secondary_groups: <%= node_data['mutable']['secondary_groups'] %>
   info: |
     # System
 

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -18,7 +18,7 @@
     <% cpus.each do |cpu| %>
     ### <%= cpu.id %>
 
-    model: <%= cpu.version %>
+    model: <%= cpu.model %>
     slot: <%= cpu.slot %>
 
     <% end %>

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -31,8 +31,8 @@
 
     | Interface | Speed | MAC |
     |-----------|-------|-----|
-    <% find_hashes_with_key_value(node_data, 'class', 'network')&.each do |net| %>
-    | <%= net['logicalname'] %> | <%= format_bits_value(net['capacity'].to_i || 0) %> | <%= net['serial'] %> |
+    <% network_devices.each do |net| %>
+    | <%= net.logicalname %> | <%= net.speed %> | <%= net.serial %> |
     <% end %>
 
 

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -1,5 +1,5 @@
-<%= node_data['Name'] %>:
-  name: <%= node_data['Name'] %>
+<%= node_data['name'] %>:
+  name: <%= node_data['name'] %>
   primary_group: <%= node_data['groups']['primary_group'] %>
   secondary_groups: <%= node_data['groups']['secondary_groups'] %>
   info: |

--- a/plugins/example_template.md.erb
+++ b/plugins/example_template.md.erb
@@ -1,7 +1,7 @@
 <%= node_data['name'] %>:
   name: <%= node_data['name'] %>
   primary_group: <%= node_data['mutable']['primary_group'] %>
-  secondary_groups: <%= node_data['mutable']['secondary_groups'] %>
+  secondary_group: <%= node_data['mutable']['secondary_groups'] %>
   info: |
     # System
 

--- a/plugins/network_device.rb
+++ b/plugins/network_device.rb
@@ -1,0 +1,12 @@
+def network_devices
+  def create_net(net_hash)
+    OpenStruct.new(net_hash).tap do |o|
+      o.speed = format_bits_value((net_hash['capacity'] || net_hash['size'] || 0).to_i)
+    end
+  end
+  network_devices = []
+  find_hashes_with_key_value(@node_data, 'class', 'network')&.each do |net|
+    network_devices << create_net(net)
+  end
+  network_devices
+end


### PR DESCRIPTION
Based on #41 
Fixes #31 

Last stage in adding support for non-standard hardware. If `modify` is called on a node that doesn't yet exist its .yaml file is created with the modified fields and a field stating `imported=false`.

Also now, if a .zip is parsed for a node that already exists their .yamls are merged rather than being overwritten. 