### PR TITLE
Expand asterisks in node names

### DIFF
--- a/lib/commands/render.rb
+++ b/lib/commands/render.rb
@@ -77,6 +77,11 @@ Invalid destination '#{@options.location}'
         # check, will loading all output cause issues with memory size?
         # probably fine - 723 nodes was 350Kb
         node_locations.each do |location|
+          unless Utils::check_file_readable?(location)
+            $stderr.puts "No node exists at #{File.expand_path(location)} - "\
+              "Skipping"
+            next
+          end
           out += parse_yaml(location, eruby, render_env)
           # this message is output through stderr in order to not interfere
           # with the output of the rendered template

--- a/lib/exceptions.rb
+++ b/lib/exceptions.rb
@@ -24,5 +24,6 @@ module Inventoryware
   class InventorywareError < RuntimeError; end
 
   class FileSysError < InventorywareError; end
+  class ParseError < InventorywareError; end
   class ArgumentError < InventorywareError; end
 end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -207,17 +207,17 @@ No node data found in #{File.expand_path(YAML_DIR)}
         found = []
         File.open(location) do |file|
           contents = file.read
-          m = contents.match(/primary_group: (.*?)$/)[1]
-          found.append(m) unless m.empty?
-          m = contents.match(/secondary_groups: (.*?)$/)[1]
-          found = found + (m.split(',')) unless m.empty?
+          m = contents.match(/primary_group: (.*?)$/)
+          found.append(m[1]) if m
+          m = contents.match(/secondary_groups: (.*?)$/)
+          found = found + (m[1].split(',')) if m
         end
         unless (found & groups).empty?
           nodes.append(location)
         end
       end
       if nodes.empty?
-        $stderr.puts "No nodes found in #{groups.join(', ')}."
+        $stderr.puts "No nodes found in #{groups.join(' or ')}."
       end
       return nodes
     end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -189,9 +189,7 @@ Output file #{location} not accessible - aborting
     def self.find_all_nodes()
       node_locations = Dir.glob(File.join(YAML_DIR, '*.yaml'))
       if node_locations.empty?
-        raise FileSysError, <<-ERROR
-No node data found in #{File.expand_path(YAML_DIR)}
-        ERROR
+        $stderr.puts "No node data found in #{File.expand_path(YAML_DIR)}"
       end
       return node_locations
     end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -135,8 +135,14 @@ Please provide at least one node.
       begin
         node_data = YAML.load_file(node_location)
       rescue Psych::SyntaxError
-        raise InventorywareError <<-ERROR
+        raise ParseError, <<-ERROR
 Error parsing yaml in #{node_location} - aborting
+        ERROR
+      end
+      # condition for if the .yaml is empty
+      unless node_data
+        raise ParseError, <<-ERROR
+Yaml in #{node_location} is empty - aborting
         ERROR
       end
       return node_data
@@ -181,6 +187,7 @@ Output file #{location} not accessible - aborting
           node_locations.push(*find_nodes_in_groups(options.group.split(',')))
         end
       end
+      #TODO move uniq & sorting here?
       return node_locations
     end
 

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -83,7 +83,22 @@ Please create it before continuing."
           nodes.delete(node)
         end
       end
-      nodes = nodes + new_nodes
+      nodes.push(*new_nodes)
+      return expand_asterisks(nodes)
+    end
+
+    def self.expand_asterisks(nodes)
+      new_nodes = []
+      nodes.each do |node|
+        if node.match(/\*/)
+          node_names = Dir.glob(File.join(YAML_DIR, node)).map { |file|
+            File.basename(file, '.yaml')
+          }
+          new_nodes.push(*node_names)
+        end
+      end
+      nodes.delete_if { |node| node.match(/\*/) }
+      nodes.push(*new_nodes)
       return nodes
     end
 

--- a/support/gather-data.sh
+++ b/support/gather-data.sh
@@ -27,11 +27,11 @@ ZIP="$BINDIR/zip"
 print_help() {
     echo "Gather Data - Collect physical and logical system configuration information"
     echo ""
-    echo "./gather-data.sh -p PRIMARY_GROUP [-g comma,separate,secondary,groups] [-t check_type] [-v]"
+    echo "./gather-data.sh [-p PRIMARY_GROUP] [-g comma,separate,secondary,groups] [-t check_type] [-v]"
     echo ""
     echo "Options:"
     echo "  -h, --help          Show this help page"
-    echo "  -p, --primary       Primary group for the node [REQUIRED]"
+    echo "  -p, --primary       Primary group for the node"
     echo "  -g, --groups        Comma-separated list of secondary groups for the node"
     echo "  -t, --type          Type of check to run (physical or logical), if not provided"
     echo "                      then both types will be collected"
@@ -107,12 +107,6 @@ done
 #
 # Validation
 #
-if [ -z $PRIGROUP ] ; then
-    echo -e "ERROR: Must provide a primary group\n"
-    print_help
-    exit 1
-fi
-
 if [ ! -z $VERBOSE ] ; then
     echo "PRIGROUP = $PRIGROUP"
     echo "SECGROUPS = $SECGROUPS"


### PR DESCRIPTION
Any node name with asterisks will be expanded using ruby's glob.

This process is carried out after range expansion so node[00-02]* is valid and will result in node00*, node01* and node02* being processed. 

Unlike nodeattr ranges, this will only return nodes that currently exist in the system.