### PR TITLE
Capture rendering errors

### DIFF
--- a/lib/commands/modifys/groups.rb
+++ b/lib/commands/modifys/groups.rb
@@ -31,7 +31,7 @@ module Inventoryware
 
           if @options.primary and @options.remove
             raise ArgumentError, <<-ERROR.chomp
-  Cannot remove a primary group
+Cannot remove a primary group
             ERROR
           end
 

--- a/lib/commands/modifys/groups.rb
+++ b/lib/commands/modifys/groups.rb
@@ -30,7 +30,7 @@ module Inventoryware
           nodes = Utils::resolve_node_options(@argv, @options, other_args)
 
           if @options.primary and @options.remove
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
   Cannot remove a primary group
             ERROR
           end

--- a/lib/commands/modifys/other.rb
+++ b/lib/commands/modifys/other.rb
@@ -31,7 +31,7 @@ module Inventoryware
           #TODO DRY up? modification is defined twice
           modification = @argv[0]
           unless modification.match(/=/)
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
   Invalid modification - must contain an '='.
             ERROR
           end
@@ -39,7 +39,7 @@ module Inventoryware
 
           protected_fields = ['primary_group', 'secondary_groups']
           if protected_fields.include?(field)
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
   Cannot modify '#{field}' this way.
             ERROR
           end

--- a/lib/commands/modifys/other.rb
+++ b/lib/commands/modifys/other.rb
@@ -32,7 +32,7 @@ module Inventoryware
           modification = @argv[0]
           unless modification.match(/=/)
             raise ArgumentError, <<-ERROR.chomp
-  Invalid modification - must contain an '='.
+Invalid modification - must contain an '='
             ERROR
           end
           field, value = modification.split('=')
@@ -40,7 +40,7 @@ module Inventoryware
           protected_fields = ['primary_group', 'secondary_groups']
           if protected_fields.include?(field)
             raise ArgumentError, <<-ERROR.chomp
-  Cannot modify '#{field}' this way.
+Cannot modify '#{field}' this way
             ERROR
           end
 

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -28,7 +28,7 @@ module Inventoryware
     class Parse < Command
       def run
         unless @argv.length() == 1
-          raise ArgumentError, <<-ERROR
+          raise ArgumentError, <<-ERROR.chomp
 The data source should be the only argument.
           ERROR
         end
@@ -70,7 +70,7 @@ The data source should be the only argument.
           contents = [data_source]
         end
         if contents.empty?
-          raise ArgumentError, <<-ERROR
+          raise ArgumentError, <<-ERROR.chomp
 No .zip files found at #{data_source}
           ERROR
         end

--- a/lib/commands/parse.rb
+++ b/lib/commands/parse.rb
@@ -29,7 +29,7 @@ module Inventoryware
       def run
         unless @argv.length() == 1
           raise ArgumentError, <<-ERROR.chomp
-The data source should be the only argument.
+The data source should be the only argument
           ERROR
         end
 

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -108,6 +108,7 @@ Invalid destination '#{out_dest}'
             unless @options.debug
               raise ParseError, <<-ERROR.chomp
 Error filling template using #{File.basename(node_location)}
+Use '--debug' for more information
               ERROR
             else
               raise e

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -36,11 +36,11 @@ module Inventoryware
           if paths.length == 1
             template = paths[0]
           elsif paths.length > 1
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 Ambiguous search term '#{template}'
             ERROR
           elsif not Utils::check_file_readable?(template)
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 Template at #{template} inaccessible
             ERROR
           end
@@ -84,7 +84,7 @@ Template at #{template} inaccessible
             # requires sudo execution - it may be that this would be better
             # changed.
             unless Utils::check_file_writable?(out_dest)
-              raise ArgumentError, <<-ERROR
+              raise ArgumentError, <<-ERROR.chomp
 Invalid destination '#{out_dest}'
               ERROR
             end

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -104,10 +104,14 @@ Invalid destination '#{out_dest}'
 
           begin
             return eruby.result(ctx)
-          rescue
-            raise ParseError, <<-ERROR.chomp
+          rescue StandardError => e
+            unless @options.debug
+              raise ParseError, <<-ERROR.chomp
 Error filling template using #{File.basename(node_location)}
-            ERROR
+              ERROR
+            else
+              raise e
+            end
           end
         end
       end

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -107,7 +107,7 @@ Invalid destination '#{out_dest}'
           rescue StandardError => e
             unless @options.debug
               raise ParseError, <<-ERROR.chomp
-Error filling template using #{File.basename(node_location)}
+Error filling template using #{File.basename(node_location)}.
 Use '--debug' for more information
               ERROR
             else

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -102,7 +102,13 @@ Invalid destination '#{out_dest}'
           render_env.instance_variable_set(:@node_data, node_data)
           ctx = render_env.instance_eval { binding }
 
-          return eruby.result(ctx)
+          begin
+            return eruby.result(ctx)
+          rescue
+            raise ParseError, <<-ERROR.chomp
+Error filling template using #{File.basename(node_location)}
+            ERROR
+          end
         end
       end
     end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -65,6 +65,8 @@ module Inventoryware
   # Display the help if there is no input arguments
   ARGV.push '--help' if ARGV.empty?
 
+  suppress_trace_class InventorywareError
+
   def self.action(command, klass)
     command.action do |args, options|
       klass.new(args, options).run!

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -79,9 +79,9 @@ module Inventoryware
   end
 
   def self.add_node_options(command)
-    command.option '--all', "Render all data in #{File.expand_path(YAML_DIR)}"
+    command.option '--all', "Select all data in #{File.expand_path(YAML_DIR)}"
     command.option '-g', '--group GROUP',
-      "Render all nodes in GROUP, commma-seperate values for multiple groups"
+      "Select all nodes in GROUP, commma-seperate values for multiple groups"
     return command
   end
 

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -158,7 +158,8 @@ module Inventoryware
     cli_syntax(c, 'TEMPLATE [NODE(S)]')
     c.description = "Create a document using nodes' data and an eRuby template"
     c.option '-l', '--location LOCATION',
-      "Output the rendered template to the specified location."
+      "Output the rendered template to the specified location"
+    c.option '-d', '--debug', "View errors while rendering the template"
     c = add_node_options(c)
     c.hidden = true
     action(c, Commands::Shows::Document)

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -53,7 +53,7 @@ module Inventoryware
     # raise an error if given path isn't a directory
     def self.exit_unless_dir(path)
       unless File.directory?(path)
-        raise FileSysError, <<-ERROR
+        raise FileSysError, <<-ERROR.chomp
 Directory #{File.expand_path(path)} not found.
 Please create it before continuing."
         ERROR
@@ -70,11 +70,11 @@ Please create it before continuing."
       if options.all
         unless argv.length == other_args.length
           unless other_args.length == 0
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 #{arg_str} should be the only argument(s) - all nodes are being parsed.
             ERROR
           else
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 There should be the no arguments - all nodes are being parsed.
             ERROR
           end
@@ -82,7 +82,7 @@ There should be the no arguments - all nodes are being parsed.
 
       elsif options.group
         if argv.length < other_args.length
-          raise ArgumentError, <<-ERROR
+          raise ArgumentError, <<-ERROR.chomp
 Please provide #{arg_str}.
           ERROR
         end
@@ -90,11 +90,11 @@ Please provide #{arg_str}.
       else
         if argv.length < other_args.length + 1
           unless other_args.length == 0
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 Please provide #{arg_str} and at least one node.
             ERROR
           else
-            raise ArgumentError, <<-ERROR
+            raise ArgumentError, <<-ERROR.chomp
 Please provide at least one node.
             ERROR
           end
@@ -112,13 +112,13 @@ Please provide at least one node.
           node_data = YAML.safe_load(f)
         end
       rescue Psych::SyntaxError
-        raise ParseError, <<-ERROR
+        raise ParseError, <<-ERROR.chomp
 Error parsing yaml in #{node_location} - aborting
         ERROR
       end
       # condition for if the .yaml is empty
       unless node_data
-        raise ParseError, <<-ERROR
+        raise ParseError, <<-ERROR.chomp
 Yaml in #{node_location} is empty - aborting
         ERROR
       end
@@ -128,7 +128,7 @@ Yaml in #{node_location} is empty - aborting
     # outputs the node data to the specified location
     def self.output_node_yaml(node_data, location)
       unless check_file_writable?(location)
-        raise FileSysError, <<-ERROR
+        raise FileSysError, <<-ERROR.chomp
 Output file #{location} not accessible - aborting
         ERROR
       end

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -55,7 +55,7 @@ module Inventoryware
       unless File.directory?(path)
         raise FileSysError, <<-ERROR.chomp
 Directory #{File.expand_path(path)} not found.
-Please create it before continuing."
+Please create it before continuing"
         ERROR
       end
       return true
@@ -71,11 +71,11 @@ Please create it before continuing."
         unless argv.length == other_args.length
           unless other_args.length == 0
             raise ArgumentError, <<-ERROR.chomp
-#{arg_str} should be the only argument(s) - all nodes are being parsed.
+#{arg_str} should be the only argument(s) - all nodes are being parsed
             ERROR
           else
             raise ArgumentError, <<-ERROR.chomp
-There should be the no arguments - all nodes are being parsed.
+There should be the no arguments - all nodes are being parsed
             ERROR
           end
         end
@@ -83,7 +83,7 @@ There should be the no arguments - all nodes are being parsed.
       elsif options.group
         if argv.length < other_args.length
           raise ArgumentError, <<-ERROR.chomp
-Please provide #{arg_str}.
+Please provide #{arg_str}
           ERROR
         end
 
@@ -91,11 +91,11 @@ Please provide #{arg_str}.
         if argv.length < other_args.length + 1
           unless other_args.length == 0
             raise ArgumentError, <<-ERROR.chomp
-Please provide #{arg_str} and at least one node.
+Please provide #{arg_str} and at least one node
             ERROR
           else
             raise ArgumentError, <<-ERROR.chomp
-Please provide at least one node.
+Please provide at least one node
             ERROR
           end
         end


### PR DESCRIPTION
Instead of giving ugly, uncontrolled errors when rendering fails now a pretty one is output. The `--debug` option can be passed to override this.

Also all errors are now properly `chomp`ed & the message prompting for `--trace` is off by default for all `InventorywareError`s