### PR TITLE
Dev/use nodeattr utils gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 
 gem 'commander', git: 'https://github.com/alces-software/commander'
 gem 'erubis'
+gem 'nodeattr_utils', github: 'alces-software/nodeattr_utils', ref: '7dcd6f4'
 gem 'require_all'
 gem 'recursive-open-struct'
 gem 'rubyzip'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,11 @@
 GIT
+  remote: git://github.com/alces-software/nodeattr_utils.git
+  revision: 7dcd6f48eb24aaced2c3dc5bfc7b6e0a2174407f
+  ref: 7dcd6f4
+  specs:
+    nodeattr_utils (0.1.0)
+
+GIT
   remote: https://github.com/alces-software/commander
   revision: 4090e181cf280f228543e35ad21af219a6d2f626
   specs:
@@ -26,6 +33,7 @@ GEM
     pry-byebug (3.6.0)
       byebug (~> 10.0)
       pry (~> 0.10)
+    recursive-open-struct (1.1.0)
     require_all (2.0.0)
     rubyzip (1.2.2)
     timers (4.3.0)
@@ -57,8 +65,10 @@ PLATFORMS
 DEPENDENCIES
   commander!
   erubis
+  nodeattr_utils!
   pry
   pry-byebug
+  recursive-open-struct
   require_all
   rubyzip
   tty-editor

--- a/lib/commands/delete.rb
+++ b/lib/commands/delete.rb
@@ -22,11 +22,9 @@
 
 module Inventoryware
   module Commands
-    class Delete < Command
+    class Delete < MultiNodeCommand
       def run
-        Utils::resolve_node_options(@argv, @options, [])
-        nodes = @argv.dig(0)
-        node_locations = Utils::select_nodes(nodes, @options)
+        node_locations = find_nodes(false)
 
         unless node_locations.empty?
           prefix = "You are about to delete"

--- a/lib/commands/delete.rb
+++ b/lib/commands/delete.rb
@@ -24,8 +24,8 @@ module Inventoryware
   module Commands
     class Delete < Command
       def run
-        other_args = []
-        nodes = Utils::resolve_node_options(@argv, @options, other_args)
+        Utils::resolve_node_options(@argv, @options, [])
+        nodes = @argv.dig(0)
         node_locations = Utils::select_nodes(nodes, @options)
 
         unless node_locations.empty?

--- a/lib/commands/delete.rb
+++ b/lib/commands/delete.rb
@@ -32,9 +32,9 @@ module Inventoryware
           prefix = "You are about to delete"
           node_locations.map! { |loc| File.expand_path(loc) }
           if node_locations.length > 1
-            node_msg = "#{prefix}:\n#{node_locations.join("\n")}\nProceed?"
+            node_msg = "#{prefix}:\n#{node_locations.join("\n")}\nProceed? (y/n)"
           else
-            node_msg = "#{prefix} #{node_locations[0]} - proceed?"
+            node_msg = "#{prefix} #{node_locations[0]} - proceed? (y/n)"
           end
           if agree(node_msg)
             node_locations.each { |node| FileUtils.rm node }

--- a/lib/commands/modifys/groups.rb
+++ b/lib/commands/modifys/groups.rb
@@ -27,7 +27,7 @@ module Inventoryware
       class Groups < Command
         def run
           other_args = ["group"]
-          nodes = Utils::resolve_node_options(@argv, @options, other_args)
+          Utils::resolve_node_options(@argv, @options, other_args)
 
           if @options.primary and @options.remove
             raise ArgumentError, <<-ERROR.chomp
@@ -35,8 +35,8 @@ Cannot remove a primary group
             ERROR
           end
 
-          #TODO DRY up? group is defined twice
           group = @argv[0]
+          nodes = @argv.dig(1)
 
           node_locations = Utils::select_nodes(nodes,
                                                @options,

--- a/lib/commands/modifys/groups.rb
+++ b/lib/commands/modifys/groups.rb
@@ -20,15 +20,11 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
-#TODO extract shared `Modifys` code to top level 'modify.rb' command file
 module Inventoryware
   module Commands
     module Modifys
-      class Groups < Command
+      class Groups < MultiNodeCommand
         def run
-          other_args = ["group"]
-          Utils::resolve_node_options(@argv, @options, other_args)
-
           if @options.primary and @options.remove
             raise ArgumentError, <<-ERROR.chomp
 Cannot remove a primary group
@@ -36,13 +32,8 @@ Cannot remove a primary group
           end
 
           group = @argv[0]
-          nodes = @argv.dig(1)
 
-          node_locations = Utils::select_nodes(nodes,
-                                               @options,
-                                               return_missing = true)
-
-          node_locations.each do |location|
+          find_nodes(true, "group").each do |location|
             node_data = Utils::read_node_or_create(location)
             if @options.primary
               node_data['mutable']['primary_group'] = group

--- a/lib/commands/modifys/location.rb
+++ b/lib/commands/modifys/location.rb
@@ -26,7 +26,10 @@ module Inventoryware
       class Location < Command
         def run
           other_args = []
-          nodes = Utils::resolve_node_options(@argv, @options, other_args)
+          Utils::resolve_node_options(@argv, @options, other_args)
+
+          nodes = @argv.dig(0)
+
           node_locations = Utils::select_nodes(nodes, @options)
 
           fields = {

--- a/lib/commands/modifys/location.rb
+++ b/lib/commands/modifys/location.rb
@@ -23,14 +23,9 @@
 module Inventoryware
   module Commands
     module Modifys
-      class Location < Command
+      class Location < MultiNodeCommand
         def run
-          other_args = []
-          Utils::resolve_node_options(@argv, @options, other_args)
-
-          nodes = @argv.dig(0)
-
-          node_locations = Utils::select_nodes(nodes, @options)
+          node_locations = find_nodes(true)
 
           fields = {
             'site' => {'name' => nil, 'value' => nil},

--- a/lib/commands/modifys/other.rb
+++ b/lib/commands/modifys/other.rb
@@ -26,7 +26,9 @@ module Inventoryware
       class Other < Command
         def run
           other_args = ["modification"]
-          nodes = Utils::resolve_node_options(@argv, @options, other_args)
+          Utils::resolve_node_options(@argv, @options, other_args)
+
+          nodes = @argv.dig(1)
 
           #TODO DRY up? modification is defined twice
           modification = @argv[0]

--- a/lib/commands/modifys/other.rb
+++ b/lib/commands/modifys/other.rb
@@ -23,15 +23,10 @@
 module Inventoryware
   module Commands
     module Modifys
-      class Other < Command
+      class Other < MultiNodeCommand
         def run
-          other_args = ["modification"]
-          Utils::resolve_node_options(@argv, @options, other_args)
-
-          nodes = @argv.dig(1)
-
-          #TODO DRY up? modification is defined twice
           modification = @argv[0]
+
           unless modification.match(/=/)
             raise ArgumentError, <<-ERROR.chomp
 Invalid modification - must contain an '='
@@ -46,11 +41,7 @@ Cannot modify '#{field}' this way
             ERROR
           end
 
-          node_locations = Utils::select_nodes(nodes,
-                                               @options,
-                                               return_missing = true)
-
-          node_locations.each do |location|
+          find_nodes(true, "modification").each do |location|
             node_data = Utils::read_node_or_create(location)
             if value
               node_data['mutable'][field] = value

--- a/lib/commands/multi_node_command.rb
+++ b/lib/commands/multi_node_command.rb
@@ -1,0 +1,37 @@
+#==============================================================================
+# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Inventoryware.
+#
+# Alces Inventoryware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Inventoryware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on Alces Inventoryware, please visit:
+# https://github.com/alces-software/inventoryware
+#==============================================================================
+
+module Inventoryware
+  module Commands
+    class MultiNodeCommand < Command
+      def find_nodes(return_missing, *other_args)
+        Utils::resolve_node_options(@argv, @options, other_args)
+
+        nodes = @argv.dig(other_args.length)
+
+        node_locations = Utils::select_nodes(nodes,
+                                             @options,
+                                             return_missing)
+      end
+    end
+  end
+end

--- a/lib/commands/multi_node_command.rb
+++ b/lib/commands/multi_node_command.rb
@@ -28,7 +28,7 @@ module Inventoryware
 
         nodes = @argv.dig(other_args.length)
 
-        node_locations = Utils::select_nodes(nodes,
+        node_locations = Utils::locate_nodes(nodes,
                                              @options,
                                              return_missing)
       end

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -29,10 +29,11 @@ module Inventoryware
       class Document < Command
         def run
           other_args = ["template"]
-          nodes = Utils::resolve_node_options(@argv, @options, other_args)
+          Utils::resolve_node_options(@argv, @options, other_args)
 
-          #TODO DRY up definition of arguments? template is declared twice
           template = @argv[0]
+          nodes = @argv.dig(1)
+
           paths = Dir.glob(File.join(TEMPLATES_DIR, "#{template}*"))
           if paths.length == 1
             template = paths[0]

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -26,13 +26,9 @@ require 'recursive-open-struct'
 module Inventoryware
   module Commands
     module Shows
-      class Document < Command
+      class Document < MultiNodeCommand
         def run
-          other_args = ["template"]
-          Utils::resolve_node_options(@argv, @options, other_args)
-
           template = @argv[0]
-          nodes = @argv.dig(1)
 
           paths = Dir.glob(File.join(TEMPLATES_DIR, "#{template}*"))
           if paths.length == 1
@@ -47,7 +43,7 @@ Template at #{template} inaccessible
             ERROR
           end
 
-          node_locations = Utils::select_nodes(nodes, @options)
+          node_locations = find_nodes(false, 'template')
           node_locations = node_locations.uniq
           node_locations = node_locations.sort_by do |location|
             File.basename(location)

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -38,6 +38,8 @@ require 'require_all'
 
 require_rel 'command'
 require_rel 'exceptions'
+# force import of super classes first
+require_rel 'commands/multi_node_command'
 require_rel 'commands/**/*.rb'
 require_rel 'lsblk_parser'
 require_rel 'search_utils'

--- a/lib/search_utils.rb
+++ b/lib/search_utils.rb
@@ -43,7 +43,7 @@ module Inventoryware
 
     # given a set of nodes and relevant options returns an expanded list
     #   of all the necessary nodes
-    def self.select_nodes(nodes, options, return_missing = false)
+    def self.locate_nodes(nodes, options, return_missing = false)
       node_locations = []
       if options.all
         node_locations = find_all_nodes

--- a/lib/search_utils.rb
+++ b/lib/search_utils.rb
@@ -20,6 +20,8 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
+require 'nodeattr_utils'
+
 module Inventoryware
   module Utils
     # return a single file from glob, error if >/< than 1 found
@@ -98,7 +100,7 @@ module Inventoryware
     # if return missing is passed, returns paths to the .yamls of non-existent
     #   nodes
     def self.find_nodes(nodes, return_missing = false)
-      nodes = expand_node_ranges(nodes)
+      nodes = expand_asterisks(NodeattrUtils::NodeParser.expand(nodes))
       node_locations = []
       nodes.each do |node|
         node_yaml = "#{node}.yaml"
@@ -116,32 +118,6 @@ module Inventoryware
         node_locations.append(node_yaml_location)
       end
       return node_locations
-    end
-
-    # given a list of nodes, expand each elem that is a range
-    def self.expand_node_ranges(nodes)
-      new_nodes = []
-      nodes.each do |node|
-        if node.match(/.*\[[0-9]+.*[0-9]+\]$/)
-          m = node.match(/^(.*)\[(.*)\]$/)
-          prefix = m[1]
-          suffix = m[2]
-          ranges = suffix.split(',')
-          ranges.each do |range|
-            if range.match(/-/)
-              num_1, num_2 = range.split('-')
-              (num_1.to_i .. num_2.to_i).each do |num|
-                new_nodes << "#{prefix}#{num.to_s.rjust(num_1.length, '0')}"
-              end
-            else
-              new_nodes << "#{prefix}#{range}"
-            end
-          end
-          nodes.delete(node)
-        end
-      end
-      nodes.push(*new_nodes)
-      return expand_asterisks(nodes)
     end
 
     def self.expand_asterisks(nodes)

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -62,8 +62,7 @@ Please create it before continuing"
     end
 
     # Errors for each way that arguments and nodes can be given incorrectly
-    # 'other_args' in an array of all non-node arguments for the command
-    #TODO make this method less awful
+    # 'other_args' is an array of all non-node arguments for the command
     def self.resolve_node_options(argv, options, other_args)
       arg_str = other_args.join(', ')
 
@@ -75,33 +74,11 @@ Please create it before continuing"
             ERROR
           else
             raise ArgumentError, <<-ERROR.chomp
-There should be the no arguments - all nodes are being parsed
-            ERROR
-          end
-        end
-
-      elsif options.group
-        if argv.length < other_args.length
-          raise ArgumentError, <<-ERROR.chomp
-Please provide #{arg_str}
-          ERROR
-        end
-
-      else
-        if argv.length < other_args.length + 1
-          unless other_args.length == 0
-            raise ArgumentError, <<-ERROR.chomp
-Please provide #{arg_str} and at least one node
-            ERROR
-          else
-            raise ArgumentError, <<-ERROR.chomp
-Please provide at least one node
+There should be no arguments - all nodes are being parsed
             ERROR
           end
         end
       end
-
-      nodes = argv[other_args.length..-1]
     end
 
     # returns the yaml hash of a file at the given location


### PR DESCRIPTION
This PR implements use of our shared nodeattr_utils gem (found at https://github.com/alces-software/nodeattr_utils) and some knock-on changes resulting from that.

Much of the change is around obeying the command validation performed by commander through its syntax checking. It makes it impossible to specify extra arguments (removing the need for some error conditions) and disallows variadic arguments (meaning that we need to move to having comma,seperated,nodes) 

Also extracts the code shared by common commands that select >=1 nodes into the MultiNodeCommand superclass 

Currently a specific commit is specified in the Gemfile. This should eventually be removed when the functionality we require is merged through to the master branch.

Fixes #70 