### PR TITLE
Fix/allow creation on edit

### DIFF
--- a/lib/commands/edit.rb
+++ b/lib/commands/edit.rb
@@ -26,13 +26,13 @@ module Inventoryware
   module Commands
     class Edit < Command
       def run
-        search = Proc.new do |val|
-          Dir.glob(File.join(YAML_DIR, "#{val}*.*"))
-        end
-        found = Utils::find_file(@argv[0], &search)
-        if found
-          TTY::Editor.open(found, command: :rvim)
-        end
+        name = @argv[0]
+        location = File.join(YAML_DIR, "#{name}.yaml")
+        # create if it doesn't exist
+        Utils::output_node_yaml(Utils::read_node_or_create(location), location)
+        # maybe don't create unless saved? i.e. don't create the file above
+        # instead save as closing
+        TTY::Editor.open(location, command: :rvim)
       end
     end
   end

--- a/lib/commands/modifys/notes.rb
+++ b/lib/commands/modifys/notes.rb
@@ -28,24 +28,21 @@ module Inventoryware
     module Modifys
       class Notes < Command
         def run
-          search = Proc.new do |val|
-            Dir.glob(File.join(YAML_DIR, "#{val}*.*"))
-          end
-          found = Utils::find_file(@argv[0], &search)
+          name = @argv[0]
+          location = File.join(YAML_DIR, "#{name}.yaml")
+          # create if it doesn't exist
 
-          if found
-            node_data = Utils::read_node_yaml(found)
-            notes = node_data['mutable'].fetch('notes', '')
-            tmp_file = Tempfile.new('inv_ware_file_')
-            begin
-              TTY::Editor.open(tmp_file.path, content: notes, command: :rvim)
-              node_data['mutable']['notes'] = tmp_file.read
-            ensure
-              tmp_file.close
-              tmp_file.unlink
-            end
-            Utils::output_node_yaml(node_data, found)
+          node_data = Utils::read_node_or_create(location)
+          notes = node_data['mutable'].fetch('notes', '')
+          tmp_file = Tempfile.new('inv_ware_file_')
+          begin
+            TTY::Editor.open(tmp_file.path, content: notes, command: :rvim)
+            node_data['mutable']['notes'] = tmp_file.read.strip
+          ensure
+            tmp_file.close
+            tmp_file.unlink
           end
+          Utils::output_node_yaml(node_data, location)
         end
       end
     end

--- a/lib/commands/shows/data.rb
+++ b/lib/commands/shows/data.rb
@@ -25,12 +25,9 @@ module Inventoryware
     module Shows
       class Data < Command
         def run
-          search = Proc.new do |val|
-            Dir.glob(File.join(YAML_DIR, "#{val}*.*"))
-          end
-          found = Utils::find_file(@argv[0], &search)
-          if found
-            File.open (found) do |file|
+          found = Utils::find_file(@argv[0], YAML_DIR)
+          if found.length == 1
+            File.open (found[0]) do |file|
               puts file.read
             end
           end

--- a/lib/commands/shows/document.rb
+++ b/lib/commands/shows/document.rb
@@ -28,19 +28,23 @@ module Inventoryware
     module Shows
       class Document < MultiNodeCommand
         def run
-          template = @argv[0]
+          template_arg = @argv[0]
 
-          paths = Dir.glob(File.join(TEMPLATES_DIR, "#{template}*"))
-          if paths.length == 1
-            template = paths[0]
-          elsif paths.length > 1
+          found = Utils::find_file(template_arg, TEMPLATES_DIR)
+
+          if found.length == 1
+            template = found[0]
+          elsif found.length > 1
             raise ArgumentError, <<-ERROR.chomp
-Ambiguous search term '#{template}'
+Please refine your search and try again.
             ERROR
-          elsif not Utils::check_file_readable?(template)
-            raise ArgumentError, <<-ERROR.chomp
-Template at #{template} inaccessible
-            ERROR
+          else
+            if not Utils::check_file_readable?(template_arg)
+              raise ArgumentError, <<-ERROR.chomp
+Template at #{template_arg} inaccessible
+              ERROR
+            end
+            template = template_arg
           end
 
           node_locations = find_nodes(false, 'template')

--- a/lib/erb_utils.rb
+++ b/lib/erb_utils.rb
@@ -86,3 +86,7 @@ def render_sub_template(subdir, name)
     return Erubis::Eruby.new(File.read(paths[0])).result(binding)
   end
 end
+
+def imported?
+  @node_hash.key?('lshw') and @node_hash.key?('lsblk')
+end

--- a/lib/search_utils.rb
+++ b/lib/search_utils.rb
@@ -24,21 +24,17 @@ require 'nodeattr_utils'
 
 module Inventoryware
   module Utils
-    # return a single file from glob, error if >/< than 1 found
-    def self.find_file(search_val, &glob)
-      results = yield(search_val)
+    # return a single file from glob, print error if >/< than 1 found
+    def self.find_file(search_val, dir)
+      results = Dir.glob(File.join(dir, "#{search_val}*"))
         if results.empty?
-          puts "No files found for '#{search_val}'"
-          return nil
+          puts "No files found for '#{search_val}' in #{File.expand_path(dir)}"
         elsif results.length > 1
           puts "Ambiguous search term '#{search_val}' - possible results are:"
           results.map! { |p| File.basename(p, File.extname(p)) }
           results.each_slice(3).each { |p| puts p.join("  ") }
-          puts "Please refine your search"
-          return nil
-        else
-          return results[0]
         end
+        return results
     end
 
     # given a set of nodes and relevant options returns an expanded list

--- a/lib/utils.rb
+++ b/lib/utils.rb
@@ -121,7 +121,6 @@ Output file #{location} not accessible - aborting
         node_data = {
           'name' => File.basename(location, '.yaml'),
           'mutable' => {},
-          'imported' => false
         }
       end
       return node_data

--- a/plugins/templates/example_template.md.erb
+++ b/plugins/templates/example_template.md.erb
@@ -5,7 +5,7 @@
   info: |
     # Sections
     
-    <% if @node_data.imported.nil? %>
+    <% if imported? %>
     1. [System](#system)
     1. [Network Devices](#network-devices)
     1. [Disks](#disks)
@@ -13,7 +13,7 @@
     <% if @node_data.mutable.notes -%>1. [Notes](#notes)<% end -%>
     <% if select_bios %>1. [BIOS Information](#bios-information)<% end %>
 
-<% if @node_data.imported.nil? %>
+<% if imported? %>
     # System <a name="system"></a>
     
     ## Model


### PR DESCRIPTION
Closes #64 and closes #68 

This PR tweaks some command functionality
 - `edit` and `modify notes` now create a .yaml file for a node if used on one that doesn't exist
 - 'imported' is no longer a key in the yaml added when a node's created on the fly. Instead a helper method has been introduced (`imported?`) that works on the node_hash instance var, returning true if `lshw` and `lsblk` info exists.
- Altered the `find_file` method so it's more reusable, used it for finding templates in `show document 