### PR TITLE
modify map command

### DIFF
--- a/lib/commands/create_node_command.rb
+++ b/lib/commands/create_node_command.rb
@@ -20,15 +20,36 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
+require 'tempfile'
+require 'tty-editor'
+
 module Inventoryware
   module Commands
-    class Edit < CreateNodeCommand
-      def action(node_data, location)
-        # output to create the node's file if it doesn't yet exist
-        Utils::output_node_yaml(node_data, location)
-        # maybe don't create unless saved? i.e. don't create the file above
-        # instead save as closing
-        TTY::Editor.open(location, command: :rvim)
+    class CreateNodeCommand < Command
+      def run
+        name = @argv[0]
+        location = File.join(YAML_DIR, "#{name}.yaml")
+        node_data = Utils::read_node_or_create(location)
+
+        action(node_data, location)
+      end
+
+      def action
+        raise NotImplementedError
+      end
+
+      def edit_with_tmp_file(text, command)
+        tmp_file = Tempfile.new('inv_ware_file_')
+        begin
+          TTY::Editor.open(tmp_file.path,
+                           content: text,
+                           command: command)
+          edited = tmp_file.read
+        ensure
+          tmp_file.close
+          tmp_file.unlink
+        end
+        return edited
       end
     end
   end

--- a/lib/commands/modifys/map.rb
+++ b/lib/commands/modifys/map.rb
@@ -1,0 +1,84 @@
+#==============================================================================
+# Copyright (C) 2018-19 Stephen F. Norledge and Alces Software Ltd.
+#
+# This file/package is part of Alces Inventoryware.
+#
+# Alces Inventoryware is free software: you can redistribute it and/or
+# modify it under the terms of the GNU Affero General Public License
+# as published by the Free Software Foundation, either version 3 of
+# the License, or (at your option) any later version.
+#
+# Alces Inventoryware is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this package.  If not, see <http://www.gnu.org/licenses/>.
+#
+# For more information on Alces Inventoryware, please visit:
+# https://github.com/alces-software/inventoryware
+#==============================================================================
+
+require 'tempfile'
+require 'tty-editor'
+
+#TODO dry up shared code with modify notes
+module Inventoryware
+  module Commands
+    module Modifys
+      class Map < Command
+        def run
+          name = @argv[0]
+          location = File.join(YAML_DIR, "#{name}.yaml")
+
+          node_data = Utils::read_node_or_create(location)
+
+          map = map_to_string(node_data['mutable']['map'])
+          tmp_file = Tempfile.new('inv_ware_file_')
+          begin
+            TTY::Editor.open(tmp_file.path,
+                             content: map,
+                             command: :"rvim +'set number'")
+            node_data['mutable']['map'] = string_to_map(tmp_file.read)
+          ensure
+            tmp_file.close
+            tmp_file.unlink
+          end
+          Utils::output_node_yaml(node_data, location)
+        end
+
+        # takes a hash with numerical keys
+        # returns a string with the keys as line numbers
+        def map_to_string(map)
+          return '' if map.nil?
+          return '' unless map.respond_to?(:key?)
+          return '' if map.keys.length < 1
+
+          unless map.keys.all? { |key| key.is_a? Integer }
+            raise ParseError, <<-ERROR.chomp
+Error parsing map - Non-integer keys
+            ERROR
+          end
+
+          str = ''
+          (1..map.keys.max).each do |i|
+            str << map.fetch(i, '')
+            str << "\n"
+          end
+          return str
+        end
+
+        # takes a string
+        # returns a hash with each line being a different numerical key
+        def string_to_map(str)
+          map = Hash.new
+          str.split("\n").each_with_index do |line, i|
+            map[i+1] = line unless line.empty?
+          end
+          return map
+        end
+      end
+    end
+  end
+end

--- a/lib/commands/modifys/map.rb
+++ b/lib/commands/modifys/map.rb
@@ -20,31 +20,14 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
-require 'tempfile'
-require 'tty-editor'
-
-#TODO dry up shared code with modify notes
 module Inventoryware
   module Commands
     module Modifys
-      class Map < Command
-        def run
-          name = @argv[0]
-          location = File.join(YAML_DIR, "#{name}.yaml")
-
-          node_data = Utils::read_node_or_create(location)
-
+      class Map < CreateNodeCommand
+        def action(node_data, location)
           map = map_to_string(node_data['mutable']['map'])
-          tmp_file = Tempfile.new('inv_ware_file_')
-          begin
-            TTY::Editor.open(tmp_file.path,
-                             content: map,
-                             command: :"rvim +'set number'")
-            node_data['mutable']['map'] = string_to_map(tmp_file.read)
-          ensure
-            tmp_file.close
-            tmp_file.unlink
-          end
+          map = string_to_map(edit_with_tmp_file(map, :"rvim +'set number'"))
+          node_data['mutable']['map'] = map
           Utils::output_node_yaml(node_data, location)
         end
 

--- a/lib/commands/modifys/notes.rb
+++ b/lib/commands/modifys/notes.rb
@@ -20,28 +20,14 @@
 # https://github.com/alces-software/inventoryware
 #==============================================================================
 
-require 'tempfile'
-require 'tty-editor'
-
 module Inventoryware
   module Commands
     module Modifys
-      class Notes < Command
-        def run
-          name = @argv[0]
-          location = File.join(YAML_DIR, "#{name}.yaml")
-          # create if it doesn't exist
-
-          node_data = Utils::read_node_or_create(location)
+      class Notes < CreateNodeCommand
+        def action(node_data, location)
           notes = node_data['mutable'].fetch('notes', '')
-          tmp_file = Tempfile.new('inv_ware_file_')
-          begin
-            TTY::Editor.open(tmp_file.path, content: notes, command: :rvim)
-            node_data['mutable']['notes'] = tmp_file.read.strip
-          ensure
-            tmp_file.close
-            tmp_file.unlink
-          end
+          notes = edit_with_tmp_file(notes, :rvim).strip
+          node_data['mutable']['notes'] = notes
           Utils::output_node_yaml(node_data, location)
         end
       end

--- a/lib/inventoryware.rb
+++ b/lib/inventoryware.rb
@@ -126,6 +126,13 @@ module Inventoryware
     action(c, Commands::Modifys::Groups)
   end
 
+  command :'modify map' do |c|
+    cli_syntax(c, 'NODE')
+    c.description = "Modify a node's mapping"
+    c.hidden = true
+    action(c, Commands::Modifys::Map)
+  end
+
   command :'modify notes' do |c|
     cli_syntax(c, 'NODE')
     c.description = "Modify a node's miscellaneous notes"


### PR DESCRIPTION
Closes #71 

Implements a `modify map` command that opens a node's 'map' in a text editor. A map is a key-value store in which all the keys are numbers and the values are one-line text. This is edited by opening the map in vim with each line corresponding to a key. Vim's line numbers have been turned on to aid this. The map is stored as a hash in the yaml & can be accessed as such in templates.

Also refactoring to remove duplicated code across `edit`, `modify map` and `modify notes`