### PR TITLE
Fix/highline use

### DIFF
--- a/lib/inventoryware/commands/delete.rb
+++ b/lib/inventoryware/commands/delete.rb
@@ -36,7 +36,7 @@ module Inventoryware
           else
             node_msg = "#{prefix} #{node_locations[0]} - proceed? (y/n)"
           end
-          if agree(node_msg)
+          if $terminal.agree(node_msg)
             node_locations.each { |node| FileUtils.rm node }
           end
         else

--- a/lib/inventoryware/commands/modifys/location.rb
+++ b/lib/inventoryware/commands/modifys/location.rb
@@ -39,7 +39,7 @@ module Inventoryware
           # Get input REPL style
           fields.each do |field, hash|
             name = hash['name'] ? hash['name'] : field
-            value = ask("Enter a #{name} or press enter to skip")
+            value = $terminal.ask("Enter a #{name} or press enter to skip")
             hash['value'] = value unless value == ''
           end
 


### PR DESCRIPTION
Highline was removed from the global namespace when we moved to the latest version of Alces commander (https://github.com/alces-software/inventoryware/commit/7bde9eb54e6cc955451e694dba131697209f1a9a). This means the old calls to highline methods resulted in undefined method errors, making `delete` and `modify location` completely unusable - fixed here. 