### PR TITLE
Fix execution with Flight Core

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -100,7 +100,7 @@ cat << EOF > /opt/flight/libexec/commands/inventory
 # For more information on the Inventoryware, please visit:
 # https://github.com/alces-software/inventoryware
 #==============================================================================
-cd $alces_INSTALL_DIR/inventoryware
+cd $alces_INSTALL_DIR/inventoryware/lib
 export FLIGHT_PROGRAM_NAME="\${flight_NAME} \$(basename \$0)"
-flexec bundle exec bin/inventory "\$@"
+flexec bundle exec ./inventoryware.rb "\$@"
 EOF


### PR DESCRIPTION
It looks like inventoryware execution has changed since the Flight Core installation script was created so the old method would get the following error:
```
[root@headnode1 [Headnode] ~]# flight inventory
bundler: command not found: bin/inventory
Install missing gem executables with `bundle install`
```

And if changed to use `lib/inventoryware.rb` it would get:
```
[root@headnode1 [Headnode] ~]# flight inventory
bundler: failed to load command: lib/inventoryware.rb (lib/inventoryware.rb)
LoadError: cannot load such file -- lib/command.rb
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:208:in `require'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:208:in `__require'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:76:in `rescue in require_all'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:58:in `require_all'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:118:in `block in require_rel'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `each'
  /appliance/inventoryware/vendor/ruby/2.5.0/gems/require_all-2.0.0/lib/require_all.rb:117:in `require_rel'
  lib/inventoryware.rb:39:in `<top (required)>'
```

So the solution is to execute from the lib directory.