### PR TITLE
Keep trailing line breaks when mapping

### DIFF
--- a/lib/inventoryware/commands/modifys/map.rb
+++ b/lib/inventoryware/commands/modifys/map.rb
@@ -58,8 +58,8 @@ Error parsing map - Non-integer keys
         # returns a hash with each line being a different numerical key
         def string_to_map(str)
           map = Hash.new
-          str.split("\n").each_with_index do |line, i|
-            map[i+1] = line unless line.empty?
+          str.lines.map(&:chomp).each_with_index do |line, i|
+            map[i+1] = line
           end
           return map
         end


### PR DESCRIPTION
Fixes #92. When creating a new map for an asset it should now retain any trailing line breaks present in the file.