### PR TITLE
Replace node references in CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,73 +6,73 @@ The commands' syntax is as follows:
 ```
 parse DATA_LOCATION
 
-delete [NODE SPEC]
+delete [ASSET SPEC]
 
-edit NODE [-c]
+edit ASSET [-c]
 
 list
 
-modify groups GROUP [NODE SPEC] [-p | -r] [-c]
+modify groups GROUP [ASSET SPEC] [-p | -r] [-c]
 
-modify location [NODE SPEC] [-c]
+modify location [ASSET SPEC] [-c]
 
-modify notes NODE [-c]
+modify notes ASSET [-c]
 
-modify map NODE [-c]
+modify map ASSET [-c]
 
-modify other KEY=[VALUE] [NODE SPEC] [-c]
+modify other KEY=[VALUE] [ASSET SPEC] [-c]
 
-show data NODE
+show data ASSET
 
-show document TEMPLATE_LOCATION [NODE SPEC] [-l DESTINATION]
+show document TEMPLATE_LOCATION [ASSET SPEC] [-l DESTINATION]
 
 ```
 
 The `parse` command processes zips at the specified location to create files in the `store/`
 directory.
 If the location is a directory all '.zips' in it will be processed. Each of these zips are expanded
-and any nested zips are processed. Only bottom level .zips are processed so don't allow any node's
+and any nested zips are processed. Only bottom level .zips are processed so don't allow any asset's
 data to be sibling to a .zip. Each zip must contain a `lshw-xml` and a `lsblk-a-P` file. A `groups`
 file will be processed if it exists.
 
-`delete` removes the data for one or more nodes after a confirmation message.
+`delete` removes the data for one or more assets after a confirmation message.
 
-`edit` opens the node's data in an editor for manual input.
+`edit` opens the asset's data in an editor for manual input.
 
-`list` lists all nodes with data in the store.
+`list` lists all assets with data in the store.
 
-The `modify groups` command adds GROUP to the  secondary groups of one or more nodes. If -p is set
-their primary group is set to GROUP. If -r is set GROUP will be removed from the nodes' secondary groups.
+The `modify groups` command adds GROUP to the  secondary groups of one or more assets. If -p is set
+their primary group is set to GROUP. If -r is set GROUP will be removed from the assets' secondary groups.
 Primary groups can't be removed, only overwritten.
 
-The `modify location` command starts input prompts to enter one location information for one or more nodes.
+The `modify location` command starts input prompts to enter one location information for one or more assets.
 
-The `modify other` command allows the setting and un-setting of arbitrary fields for one or more nodes.
-FIELD is set to VALUE and if VALUE is blank the field is removed from the nodes' data.
-A node's groups cannot be set this way because of the special constraints for those fields; for groups please
+The `modify other` command allows the setting and un-setting of arbitrary fields for one or more assets.
+FIELD is set to VALUE and if VALUE is blank the field is removed from the assets' data.
+An asset's groups cannot be set this way because of the special constraints for those fields; for groups please
 use `modify groups`.
 
-`modify notes` opens an editor for a node's 'notes' section. This is general data store that maintains text
+`modify notes` opens an editor for an asset's 'notes' section. This is general data store that maintains text
 formatting.
 
-The `modify map` command opens an editor for a node's 'map' section. A 'map' is a key:value store where all
+The `modify map` command opens an editor for an asset's 'map' section. A 'map' is a key:value store where all
 the keys are numerical and represent port numbers and the values are text. The lines of the editor refer to
 the keys of the map, the editor has its line numbers set to 'on' to aid entry.
 
-`show data` displays the selected node's data in the terminal.
+`show data` displays the selected asset's data in the terminal.
 
 The `show document` command fills eRuby templates using stored data. The first argument is the template to
 be filled, see 'Templates' section for details. First the argument's value will be used to search the
 `templates/` directory then, if nothing is found, it will be used as a path. The output will be passed to stdout
 unless a destination is specified with the `-l` option.
 
-NODE_SPEC refers to specification of more than one node. This is done in the same way for all commands.
-Either nodes names are given, separated by commas, or `--all` can be passed to supersede this process the
-data for all nodes directory. Additionally groups can be selected with the `-g` option in which case all
-nodes in the specified groups will be processed.
+ASSET_SPEC refers to specification of more than one asset. This is done in the same way for all commands.
+Either assets names are given, separated by commas, or `--all` can be passed to supersede this process the
+data for all assets directory. Additionally groups can be selected with the `-g` option in which case all
+assets in the specified groups will be processed.
 
 For all the editing and modifying commands if the `--create/-c` option is used a new file will be created
-for each node if it doesn't already exist.
+for each asset if it doesn't already exist.
 
 ## Installation
 

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -130,7 +130,7 @@ module Inventoryware
 
     command :'modify map' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Modify mapping data for a asset"
+      c.description = "Modify mapping data for an asset"
       c.hidden = true
       add_create_option(c)
       action(c, Commands::Modifys::Map)
@@ -138,7 +138,7 @@ module Inventoryware
 
     command :'modify notes' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Modify miscellaneous notes for a asset"
+      c.description = "Modify miscellaneous notes for an asset"
       c.hidden = true
       add_create_option(c)
       action(c, Commands::Modifys::Notes)
@@ -152,7 +152,7 @@ module Inventoryware
 
     command :edit do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Edit stored data for a asset"
+      c.description = "Edit stored data for an asset"
       add_create_option(c)
       action(c, Commands::Edit)
     end
@@ -165,7 +165,7 @@ module Inventoryware
 
     command :'show data' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "View stored data for a asset"
+      c.description = "View stored data for an asset"
       c.hidden = true
       action(c, Commands::Shows::Data)
     end

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -76,14 +76,14 @@ module Inventoryware
       end
 
       def add_multi_node_options(command)
-        command.option '--all', "Select all nodes"
+        command.option '--all', "Select all assets"
         command.option '-g', '--group GROUP',
-                       "Select nodes in GROUP, specify commma-separated list for multiple groups"
+                       "Select assets in GROUP, specify commma-separated list for multiple groups"
       end
 
       def add_create_option(command)
         command.option '-c', '--create',
-                       "Create specified node(s) if they don't exist"
+                       "Create specified asset(s) if they don't exist"
       end
     end
 
@@ -95,13 +95,13 @@ module Inventoryware
 
     command :modify do |c|
       cli_syntax(c, 'SUBCOMMAND')
-      c.description = 'Change mutable node data'
+      c.description = 'Change mutable asset data'
       c.configure_sub_command(self)
     end
 
     command :'modify other' do |c|
       cli_syntax(c, 'KEY=VALUE [NODE_SPEC]')
-      c.description = "Modify arbitrary data for one or more nodes"
+      c.description = "Modify arbitrary data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
       add_create_option(c)
@@ -110,7 +110,7 @@ module Inventoryware
 
     command :'modify location' do |c|
       cli_syntax(c, '[NODE_SPEC]')
-      c.description = "Modify location data for one or more nodes"
+      c.description = "Modify location data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
       add_create_option(c)
@@ -119,18 +119,18 @@ module Inventoryware
 
     command :'modify groups' do |c|
       cli_syntax(c, 'GROUP [NODE_SPEC]')
-      c.description = "Modify group data for one or more nodes"
+      c.description = "Modify group data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
       add_create_option(c)
-      c.option '-p', '--primary', "Modify the primary group of one or more nodes"
-      c.option '-r', '--remove', "Remove one or more nodes from this group"
+      c.option '-p', '--primary', "Modify the primary group of one or more assets"
+      c.option '-r', '--remove', "Remove one or more assets from this group"
       action(c, Commands::Modifys::Groups)
     end
 
     command :'modify map' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Modify mapping data for a node"
+      c.description = "Modify mapping data for a asset"
       c.hidden = true
       add_create_option(c)
       action(c, Commands::Modifys::Map)
@@ -138,7 +138,7 @@ module Inventoryware
 
     command :'modify notes' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Modify miscellaneous notes for a node"
+      c.description = "Modify miscellaneous notes for a asset"
       c.hidden = true
       add_create_option(c)
       action(c, Commands::Modifys::Notes)
@@ -146,13 +146,13 @@ module Inventoryware
 
     command :list do |c|
       cli_syntax(c)
-      c.description = "List all nodes that have stored data"
+      c.description = "List all assets that have stored data"
       action(c, Commands::List)
     end
 
     command :edit do |c|
       cli_syntax(c, 'NODE')
-      c.description = "Edit stored data for a node"
+      c.description = "Edit stored data for a asset"
       add_create_option(c)
       action(c, Commands::Edit)
     end
@@ -165,14 +165,14 @@ module Inventoryware
 
     command :'show data' do |c|
       cli_syntax(c, 'NODE')
-      c.description = "View stored data for a node"
+      c.description = "View stored data for a asset"
       c.hidden = true
       action(c, Commands::Shows::Data)
     end
 
     command :'show document' do |c|
       cli_syntax(c, 'TEMPLATE [NODE_SPEC]')
-      c.description = "Render a document template for one or more nodes"
+      c.description = "Render a document template for one or more assets"
       c.option '-l', '--location LOCATION',
                "Output the rendered template to the specified location"
       c.option '-d', '--debug', "Display rendering errors"
@@ -183,7 +183,7 @@ module Inventoryware
 
     command :delete do |c|
       cli_syntax(c, '[NODE_SPEC]')
-      c.description = "Delete the stored data for one or more nodes"
+      c.description = "Delete the stored data for one or more assets"
       add_multi_node_options(c)
       action(c, Commands::Delete)
     end

--- a/lib/inventoryware/cli.rb
+++ b/lib/inventoryware/cli.rb
@@ -100,7 +100,7 @@ module Inventoryware
     end
 
     command :'modify other' do |c|
-      cli_syntax(c, 'KEY=VALUE [NODE_SPEC]')
+      cli_syntax(c, 'KEY=VALUE [ASSET_SPEC]')
       c.description = "Modify arbitrary data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
@@ -109,7 +109,7 @@ module Inventoryware
     end
 
     command :'modify location' do |c|
-      cli_syntax(c, '[NODE_SPEC]')
+      cli_syntax(c, '[ASSET_SPEC]')
       c.description = "Modify location data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
@@ -118,7 +118,7 @@ module Inventoryware
     end
 
     command :'modify groups' do |c|
-      cli_syntax(c, 'GROUP [NODE_SPEC]')
+      cli_syntax(c, 'GROUP [ASSET_SPEC]')
       c.description = "Modify group data for one or more assets"
       c.hidden = true
       add_multi_node_options(c)
@@ -129,7 +129,7 @@ module Inventoryware
     end
 
     command :'modify map' do |c|
-      cli_syntax(c, 'NODE')
+      cli_syntax(c, 'ASSET')
       c.description = "Modify mapping data for an asset"
       c.hidden = true
       add_create_option(c)
@@ -137,7 +137,7 @@ module Inventoryware
     end
 
     command :'modify notes' do |c|
-      cli_syntax(c, 'NODE')
+      cli_syntax(c, 'ASSET')
       c.description = "Modify miscellaneous notes for an asset"
       c.hidden = true
       add_create_option(c)
@@ -151,7 +151,7 @@ module Inventoryware
     end
 
     command :edit do |c|
-      cli_syntax(c, 'NODE')
+      cli_syntax(c, 'ASSET')
       c.description = "Edit stored data for an asset"
       add_create_option(c)
       action(c, Commands::Edit)
@@ -164,14 +164,14 @@ module Inventoryware
     end
 
     command :'show data' do |c|
-      cli_syntax(c, 'NODE')
+      cli_syntax(c, 'ASSET')
       c.description = "View stored data for an asset"
       c.hidden = true
       action(c, Commands::Shows::Data)
     end
 
     command :'show document' do |c|
-      cli_syntax(c, 'TEMPLATE [NODE_SPEC]')
+      cli_syntax(c, 'TEMPLATE [ASSET_SPEC]')
       c.description = "Render a document template for one or more assets"
       c.option '-l', '--location LOCATION',
                "Output the rendered template to the specified location"
@@ -182,7 +182,7 @@ module Inventoryware
     end
 
     command :delete do |c|
-      cli_syntax(c, '[NODE_SPEC]')
+      cli_syntax(c, '[ASSET_SPEC]')
       c.description = "Delete the stored data for one or more assets"
       add_multi_node_options(c)
       action(c, Commands::Delete)

--- a/lib/inventoryware/commands/delete.rb
+++ b/lib/inventoryware/commands/delete.rb
@@ -40,7 +40,7 @@ module Inventoryware
             node_locations.each { |node| FileUtils.rm node }
           end
         else
-          puts "No nodes found"
+          puts "No assets found"
         end
       end
     end

--- a/lib/inventoryware/commands/multi_node_command.rb
+++ b/lib/inventoryware/commands/multi_node_command.rb
@@ -46,11 +46,11 @@ module Inventoryware
           unless argv.length == other_args.length
             unless other_args.length == 0
               raise ArgumentError, <<-ERROR.chomp
-#{arg_str} should be the only argument(s) - all nodes are being parsed
+#{arg_str} should be the only argument(s) - all assets are being parsed
               ERROR
             else
               raise ArgumentError, <<-ERROR.chomp
-There should be no arguments - all nodes are being parsed
+There should be no arguments - all assets are being parsed
               ERROR
             end
           end
@@ -78,7 +78,7 @@ There should be no arguments - all nodes are being parsed
       def find_all_nodes()
         node_locations = Dir.glob(File.join(Config.yaml_dir, '*.yaml'))
         if node_locations.empty?
-          $stderr.puts "No node data found "\
+          $stderr.puts "No asset data found "\
             "in #{File.expand_path(Config.yaml_dir)}"
         end
         return node_locations
@@ -105,7 +105,7 @@ There should be no arguments - all nodes are being parsed
           end
         end
         if nodes.empty?
-          $stderr.puts "No nodes found in #{groups.join(' or ')}."
+          $stderr.puts "No assets found in #{groups.join(' or ')}."
         end
         return nodes
       end
@@ -116,7 +116,7 @@ There should be no arguments - all nodes are being parsed
       #   nodes
       def find_single_nodes(node_str, return_missing = false)
         nodes = expand_asterisks(NodeattrUtils::NodeParser.expand(node_str))
-        $stderr.puts "No nodes found for '#{node_str}'" if nodes.empty?
+        $stderr.puts "No assets found for '#{node_str}'" if nodes.empty?
         node_locations = []
         nodes.each do |node|
           node_yaml = "#{node}.yaml"

--- a/lib/inventoryware/commands/single_node_command.rb
+++ b/lib/inventoryware/commands/single_node_command.rb
@@ -36,7 +36,7 @@ module Inventoryware
         # error to prevent confusion if attempting to provide >1 node
         if NodeattrUtils::NodeParser.expand(name).length > 1
           raise ArgumentError, <<-ERROR.chomp
-Issue with argument name, please only provide a single node
+Issue with argument name, please only provide a single asset
           ERROR
         end
 


### PR DESCRIPTION
All references in the CLI to nodes have been replaced with assets. 

Resolves #88 when merged.