### PR TITLE
Allow local paths

### DIFF
--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -47,16 +47,16 @@ The data source should be the only argument
           config.string_keys = true
         end
 
+        # determine if given path is absolute
+        file_name = @argv[0]
+        file_path = Pathname.new(file_name)
+        unless file_path.absolute?
+          puts "Searching for file by name: #{file_name}"
+          file_path = Dir.glob("/**/#{file_name}")[0]
+        end
+
         begin
           top_dir = Dir.mktmpdir('inv_ware_')
-
-          # determine if given path is absolute
-          file_name = @argv[0]
-          file_path = Pathname.new(file_name)
-          unless file_path.absolute?
-            puts "Searching for file by name: #{file_name}"
-            file_path = Dir.glob("/**/#{file_name}")[0]
-          end
 
           # get all zips in in the source, if it's a dir or not
           top_lvl_zip_paths = expand_dir(file_path)

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -58,6 +58,12 @@ The data source should be the only argument
           raise ArgumentError, <<-ERROR.chomp
 Please refine your search and try again.
           ERROR
+        else
+          if not Utils.check_file_readable?(file_path)
+            raise ArgumentError, <<-ERROR.chomp
+Zip file at #{file_path} inaccessible.
+            ERROR
+          end
         end
 
         begin

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -53,7 +53,7 @@ The data source should be the only argument
           # determine if given path is absolute
           file_path = Pathname.new(@argv[0])
           unless file_path.absolute?
-            file_path = Dir.glob("/**/#{@argv[0]}")
+            file_path = Dir.glob("/**/#{@argv[0]}")[0]
           end
 
           # get all zips in in the source, if it's a dir or not

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -27,6 +27,7 @@ require 'inventoryware/utils'
 
 require 'fileutils'
 require 'xmlhasher'
+require 'pathname'
 require 'yaml'
 require 'zip'
 

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -56,7 +56,7 @@ The data source should be the only argument
           end
 
           # get all zips in in the source, if it's a dir or not
-          top_lvl_zip_paths = expand_dir(@argv[0])
+          top_lvl_zip_paths = expand_dir(file_path)
 
           # for each of these, extract to /tmp/
           top_lvl_zip_paths.each { |zip_path| extract_zip(zip_path, top_dir) }

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -51,7 +51,6 @@ The data source should be the only argument
         file_name = @argv[0]
         file_path = Pathname.new(file_name)
         unless file_path.absolute?
-          puts "Searching for file by name: #{file_name}"
           file_path = Dir.glob("/**/#{file_name}")[0]
         end
 

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -53,6 +53,7 @@ The data source should be the only argument
           # determine if given path is absolute
           file_path = Pathname.new(@argv[0])
           unless file_path.absolute?
+            puts "Searching for file by name: #{@argv[0]}"
             file_path = Dir.glob("/**/#{@argv[0]}")[0]
           end
 

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -50,6 +50,7 @@ The data source should be the only argument
         begin
           top_dir = Dir.mktmpdir('inv_ware_')
 
+          # determine if given path is absolute
           file_path = Pathname.new(@argv[0])
           unless file_path.absolute?
             file_path = Dir.glob("/**/#{@argv[0]}")

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -55,6 +55,12 @@ The data source should be the only argument
           file_path = Dir.glob("/**/#{file_name}")[0]
         end
 
+        if file_path.nil?
+          raise ArgumentError, <<-ERROR.chomp
+Please refine your search and try again.
+          ERROR
+        end
+
         begin
           top_dir = Dir.mktmpdir('inv_ware_')
 

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -51,10 +51,11 @@ The data source should be the only argument
           top_dir = Dir.mktmpdir('inv_ware_')
 
           # determine if given path is absolute
-          file_path = Pathname.new(@argv[0])
+          file_name = @argv[0]
+          file_path = Pathname.new(file_name)
           unless file_path.absolute?
-            puts "Searching for file by name: #{@argv[0]}"
-            file_path = Dir.glob("/**/#{@argv[0]}")[0]
+            puts "Searching for file by name: #{file_name}"
+            file_path = Dir.glob("/**/#{file_name}")[0]
           end
 
           # get all zips in in the source, if it's a dir or not

--- a/lib/inventoryware/commands/parse.rb
+++ b/lib/inventoryware/commands/parse.rb
@@ -50,6 +50,11 @@ The data source should be the only argument
         begin
           top_dir = Dir.mktmpdir('inv_ware_')
 
+          file_path = Pathname.new(@argv[0])
+          unless file_path.absolute?
+            file_path = Dir.glob("/**/#{@argv[0]}")
+          end
+
           # get all zips in in the source, if it's a dir or not
           top_lvl_zip_paths = expand_dir(@argv[0])
 


### PR DESCRIPTION
When giving a path to the `parse` command it will check if the initial path is absolute. If it isn't then it will attempt to find the file within the machine. This uses a `glob` and could potentially take some time to locate the file, if it even exists. However given the example this was the best solution I could find.

Resolves #87 when merged.